### PR TITLE
Sort out series

### DIFF
--- a/scripts/add_stories_to_multiple_series.py
+++ b/scripts/add_stories_to_multiple_series.py
@@ -1,7 +1,42 @@
-# First: set up Calibre Fanfic Library so that there are multiple series columns, and you can search across all of them.
-# There is a link for this in todoist. :)
-# Next: export all fics from calibre that are in a series.
-# It looks like, if a fic is in more than one series, we save it into a different series than is added to the epub front
-# page by fanficfare.
-# So, look for all fics that have more than one series according to that measure?
-# Then get the metadata from AO3, and add multiple series to the ebook metadata, and save.
+from subprocess import PIPE, STDOUT, check_output
+
+
+# The AO3 metadata that we get from FanficFare includes these series keys as well as
+# "series". Since "series" is a default Calibre field, we can ignore it here.
+AO3_SERIES_KEYS = ["series00", "series01", "series02", "series03"]
+PATH = '--with-library "/home/rae/Calibre Fanfic Library"'
+
+
+def check_or_create_extra_series_columns(path):
+    res = check_output(
+        "calibredb custom_columns {}".format(path),
+        shell=True,
+        stderr=STDOUT,
+        stdin=PIPE,
+    )
+    # Get rid of the number after each column name, e.g. "columnname (1)"
+    columns = [c.split(" ")[0] for c in res.decode("utf-8").split("\n")]
+    print(columns)
+    print(set(columns).intersection(AO3_SERIES_KEYS))
+    print(set(AO3_SERIES_KEYS))
+    if set(columns).intersection(AO3_SERIES_KEYS) == set(AO3_SERIES_KEYS):
+        print("Custom AO3 series columns are in Calibre Library")
+        return
+
+    print("Adding custom AO3 series columns to Calibre library")
+    for c in AO3_SERIES_KEYS:
+        check_output(
+            "calibredb add_custom_column {} {} {} series".format(path, c, c),
+            shell=True,
+            stderr=STDOUT,
+            stdin=PIPE,
+        )
+
+
+if __name__ == "__main__":
+    # Next: export all fics from calibre that are in a series.
+    # It looks like, if a fic is in more than one series, we save it into a different series than is added to the epub front
+    # page by fanficfare.
+    # So, look for all fics that have more than one series according to that measure?
+    # Then get the metadata from AO3, and add multiple series to the ebook metadata, and save.
+    check_or_create_extra_series_columns(PATH)

--- a/scripts/add_stories_to_multiple_series.py
+++ b/scripts/add_stories_to_multiple_series.py
@@ -22,9 +22,6 @@ def check_or_create_extra_series_columns(path):
     )
     # Get rid of the number after each column name, e.g. "columnname (1)"
     columns = [c.split(" ")[0] for c in res.decode("utf-8").split("\n")]
-    print(columns)
-    print(set(columns).intersection(AO3_SERIES_KEYS))
-    print(set(AO3_SERIES_KEYS))
     if set(columns).intersection(AO3_SERIES_KEYS) == set(AO3_SERIES_KEYS):
         print("Custom AO3 series columns are in Calibre Library")
     else:

--- a/scripts/add_stories_to_multiple_series.py
+++ b/scripts/add_stories_to_multiple_series.py
@@ -1,0 +1,7 @@
+# First: set up Calibre Fanfic Library so that there are multiple series columns, and you can search across all of them.
+# There is a link for this in todoist. :)
+# Next: export all fics from calibre that are in a series.
+# It looks like, if a fic is in more than one series, we save it into a different series than is added to the epub front
+# page by fanficfare.
+# So, look for all fics that have more than one series according to that measure?
+# Then get the metadata from AO3, and add multiple series to the ebook metadata, and save.

--- a/scripts/add_stories_to_multiple_series.py
+++ b/scripts/add_stories_to_multiple_series.py
@@ -4,12 +4,18 @@ from subprocess import PIPE, STDOUT, check_output
 # The AO3 metadata that we get from FanficFare includes these series keys as well as
 # "series". Since "series" is a default Calibre field, we can ignore it here.
 AO3_SERIES_KEYS = ["series00", "series01", "series02", "series03"]
-PATH = '--with-library "/home/rae/Calibre Fanfic Library"'
+PATH = '"/home/rae/Calibre Fanfic Library"'
+ADD_GROUPED_SEARCH_SCRIPT = '''from calibre.library import db
+
+db = db(%s).new_api
+db.set_pref("grouped_search_terms", {"allseries": ["series", "series00", "series01", "series02", "series03"]})
+print(db.pref("grouped_search_terms"))
+'''
 
 
 def check_or_create_extra_series_columns(path):
     res = check_output(
-        "calibredb custom_columns {}".format(path),
+        "calibredb custom_columns --with-library {}".format(path),
         shell=True,
         stderr=STDOUT,
         stdin=PIPE,
@@ -21,16 +27,31 @@ def check_or_create_extra_series_columns(path):
     print(set(AO3_SERIES_KEYS))
     if set(columns).intersection(AO3_SERIES_KEYS) == set(AO3_SERIES_KEYS):
         print("Custom AO3 series columns are in Calibre Library")
-        return
+    else:
+        print("Adding custom AO3 series columns to Calibre library")
+        for c in AO3_SERIES_KEYS:
+            check_output(
+                "calibredb add_custom_column --with-library {} {} {} series".format(path, c, c),
+                shell=True,
+                stderr=STDOUT,
+                stdin=PIPE,
+            )
 
-    print("Adding custom AO3 series columns to Calibre library")
-    for c in AO3_SERIES_KEYS:
-        check_output(
-            "calibredb add_custom_column {} {} {} series".format(path, c, c),
-            shell=True,
-            stderr=STDOUT,
-            stdin=PIPE,
-        )
+    print("Adding grouped search term 'allseries' to Calibre Library")
+    _add_grouped_search_terms(path)
+
+
+def _add_grouped_search_terms(path):
+    # Add a new grouped search term "allseries" so that Calibre can search across all
+    # the series columns.
+    script = ADD_GROUPED_SEARCH_SCRIPT % path
+    res = check_output(
+        "calibre-debug -c '{}'".format(script),
+        shell=True,
+        stderr=STDOUT,
+        stdin=PIPE,
+    )
+    print(res)
 
 
 if __name__ == "__main__":

--- a/scripts/add_stories_to_multiple_series.py
+++ b/scripts/add_stories_to_multiple_series.py
@@ -1,17 +1,26 @@
+import json
+import re
+from os import listdir
+from os.path import isfile, join
 from subprocess import PIPE, STDOUT, check_output
 from sys import argv
+from tempfile import mkdtemp
 
+from ebooklib import epub
 
 # The AO3 metadata that we get from FanficFare includes these series keys as well as
 # "series". Since "series" is a default Calibre field, we can ignore it here.
 AO3_SERIES_KEYS = ["series00", "series01", "series02", "series03"]
 PATH = '"/home/rae/Calibre Fanfic Library"'
-ADD_GROUPED_SEARCH_SCRIPT = '''from calibre.library import db
+ADD_GROUPED_SEARCH_SCRIPT = """from calibre.library import db
 
 db = db(%s).new_api
 db.set_pref("grouped_search_terms", {"allseries": ["series", "series00", "series01", "series02", "series03"]})
 print(db.pref("grouped_search_terms"))
-'''
+"""
+series_link_pattern = re.compile(
+    '<a class="serieslink" href="https://archiveofourown\.org/series/([\d]+)">(.+) \[[\d]*]</a>'
+)
 
 
 def check_or_create_extra_series_columns(path):
@@ -29,7 +38,9 @@ def check_or_create_extra_series_columns(path):
         print("Adding custom AO3 series columns to Calibre library")
         for c in AO3_SERIES_KEYS:
             check_output(
-                "calibredb add_custom_column --with-library {} {} {} series".format(path, c, c),
+                "calibredb add_custom_column --with-library {} {} {} series".format(
+                    path, c, c
+                ),
                 shell=True,
                 stderr=STDOUT,
                 stdin=PIPE,
@@ -52,14 +63,90 @@ def _add_grouped_search_terms(path):
     print(res)
 
 
+def find_books_in_series(path):
+    res = check_output(
+        "calibredb list --with-library {} --search series:true --fields id,series,series_index --for-machine".format(
+            path
+        ),
+        shell=True,
+        stderr=STDOUT,
+        stdin=PIPE,
+    )
+    book_data = json.loads(res.decode("utf-8"))
+    print("Found data about {} books that belong to series".format(len(book_data)))
+    return book_data
+
+
+def filter_books_in_multiple_series(path, book_data):
+    n = 0
+    series_ids_to_import = []
+    for book in book_data:
+        if n % 10 == 0:
+            print("Processed {} books".format(str(n)))
+
+        series_1 = book["series"]
+        loc = mkdtemp()
+        check_output(
+            'calibredb export --dont-save-cover --dont-write-opf --single-dir --to-dir "{}" --with-library {} {}'.format(
+                loc, path, book["id"]
+            ),
+            shell=True,
+            stdin=PIPE,
+            stderr=STDOUT,
+        )
+        story_file = _get_files(loc, ".epub", True)[0]
+        book = epub.read_epub(story_file)
+        title_page = book.get_item_with_id("title_page")
+        html = str(title_page.get_body_content())
+
+        m2 = series_link_pattern.search(html)
+        if m2:
+            series_2 = m2.group(2).replace("\\'", "'")
+            series_2_id = m2.group(1)
+            if series_1 != series_2:
+                series_ids_to_import.append(series_2_id)
+                print(
+                    "{} (series saved in Calibre) does not match {} ({}) (series in epub title page)".format(
+                        series_1, series_2, series_2_id
+                    )
+                )
+        else:
+            print("No series title found!")
+
+        n += 1
+
+    return series_ids_to_import
+
+
+def _get_files(mypath, filetype=None, fullpath=False):
+    if filetype:
+        ans = [
+            f
+            for f in listdir(mypath)
+            if isfile(join(mypath, f)) and f.endswith(filetype)
+        ]
+    else:
+        ans = [f for f in listdir(mypath) if isfile(join(mypath, f))]
+    if fullpath:
+        return [join(mypath, f) for f in ans]
+    else:
+        return ans
+
+
 if __name__ == "__main__":
-    # Next: export all fics from calibre that are in a series.
-    # It looks like, if a fic is in more than one series, we save it into a different series than is added to the epub front
-    # page by fanficfare.
-    # So, look for all fics that have more than one series according to that measure?
-    # Then get the metadata from AO3, and add multiple series to the ebook metadata, and save.
     path = PATH
     if len(argv) > 1:
         path = argv[1]
 
     check_or_create_extra_series_columns(path)
+
+    # Next: export all fics from calibre that are in a series.
+    # It looks like, if a fic is in more than one series, we save it into a different
+    # series than is added to the epub front page by fanficfare.
+    # So, look for all fics that have more than one series according to that measure.
+
+    books_in_series = find_books_in_series(path)
+    series_to_reimport = filter_books_in_multiple_series(path, books_in_series)
+
+    # Then get the metadata from AO3, and add multiple series to the ebook metadata,
+    # and save.

--- a/scripts/add_stories_to_multiple_series.py
+++ b/scripts/add_stories_to_multiple_series.py
@@ -148,5 +148,8 @@ if __name__ == "__main__":
     books_in_series = find_books_in_series(path)
     series_to_reimport = filter_books_in_multiple_series(path, books_in_series)
 
-    # Then get the metadata from AO3, and add multiple series to the ebook metadata,
-    # and save.
+    # Then output series ids so they can be manually reimported.
+    print(
+        "Series that should be reimported, because they contain books that have not had the series saved on them:"
+    )
+    print(",".join(series_to_reimport))

--- a/scripts/add_stories_to_multiple_series.py
+++ b/scripts/add_stories_to_multiple_series.py
@@ -1,4 +1,5 @@
 from subprocess import PIPE, STDOUT, check_output
+from sys import argv
 
 
 # The AO3 metadata that we get from FanficFare includes these series keys as well as
@@ -57,4 +58,8 @@ if __name__ == "__main__":
     # page by fanficfare.
     # So, look for all fics that have more than one series according to that measure?
     # Then get the metadata from AO3, and add multiple series to the ebook metadata, and save.
-    check_or_create_extra_series_columns(PATH)
+    path = PATH
+    if len(argv) > 1:
+        path = argv[1]
+
+    check_or_create_extra_series_columns(path)

--- a/scripts/books_in_series.json
+++ b/scripts/books_in_series.json
@@ -1,0 +1,13027 @@
+[
+  {
+    "id": 2,
+    "series": "Remember This Cold",
+    "series_index": 17.0
+  },
+  {
+    "id": 3,
+    "series": "Relativity",
+    "series_index": 1.0
+  },
+  {
+    "id": 9,
+    "series": "all that glitters is not gold",
+    "series_index": 3.0
+  },
+  {
+    "id": 11,
+    "series": "To Die as Lovers May",
+    "series_index": 11.0
+  },
+  {
+    "id": 14,
+    "series": "The Borgias Works",
+    "series_index": 1.0
+  },
+  {
+    "id": 15,
+    "series": "Classpect-talia",
+    "series_index": 1.0
+  },
+  {
+    "id": 16,
+    "series": "Heroes in the Sky",
+    "series_index": 1.0
+  },
+  {
+    "id": 18,
+    "series": "Heroes in the Sky",
+    "series_index": 2.0
+  },
+  {
+    "id": 20,
+    "series": "Heroes in the Sky",
+    "series_index": 3.0
+  },
+  {
+    "id": 21,
+    "series": "all that glitters is not gold",
+    "series_index": 4.0
+  },
+  {
+    "id": 24,
+    "series": "Innocent When You Dream",
+    "series_index": 2.0
+  },
+  {
+    "id": 28,
+    "series": "the long way down",
+    "series_index": 2.0
+  },
+  {
+    "id": 29,
+    "series": "out of the dust; into the dark",
+    "series_index": 7.0
+  },
+  {
+    "id": 30,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 126.0
+  },
+  {
+    "id": 31,
+    "series": "we will be dangerous acquaintances with a history",
+    "series_index": 2.0
+  },
+  {
+    "id": 33,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 106.0
+  },
+  {
+    "id": 36,
+    "series": "all that glitters is not gold",
+    "series_index": 5.0
+  },
+  {
+    "id": 38,
+    "series": "Relativity",
+    "series_index": 2.0
+  },
+  {
+    "id": 43,
+    "series": "Mirrorism",
+    "series_index": 1.0
+  },
+  {
+    "id": 47,
+    "series": "all that glitters is not gold",
+    "series_index": 6.0
+  },
+  {
+    "id": 49,
+    "series": "Gehenna",
+    "series_index": 6.0
+  },
+  {
+    "id": 50,
+    "series": "boarding school au",
+    "series_index": 1.0
+  },
+  {
+    "id": 51,
+    "series": "Commander Eliza Shepard",
+    "series_index": 13.0
+  },
+  {
+    "id": 52,
+    "series": "Remember This Cold",
+    "series_index": 39.0
+  },
+  {
+    "id": 54,
+    "series": "Grim Tales",
+    "series_index": 3.0
+  },
+  {
+    "id": 55,
+    "series": "drabbles",
+    "series_index": 2.0
+  },
+  {
+    "id": 59,
+    "series": "Remember This Cold",
+    "series_index": 59.0
+  },
+  {
+    "id": 60,
+    "series": "trans victor verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 61,
+    "series": "Journey of the Featherless",
+    "series_index": 1.0
+  },
+  {
+    "id": 64,
+    "series": "drabbles",
+    "series_index": 3.0
+  },
+  {
+    "id": 65,
+    "series": "Commander Eliza Shepard",
+    "series_index": 12.0
+  },
+  {
+    "id": 66,
+    "series": "Remember This Cold",
+    "series_index": 60.0
+  },
+  {
+    "id": 67,
+    "series": "Pictures at an Exhibition",
+    "series_index": 1.0
+  },
+  {
+    "id": 70,
+    "series": "all that glitters is not gold",
+    "series_index": 7.0
+  },
+  {
+    "id": 73,
+    "series": "Author's Favorites",
+    "series_index": 7.0
+  },
+  {
+    "id": 75,
+    "series": "Remember This Cold",
+    "series_index": 61.0
+  },
+  {
+    "id": 76,
+    "series": "Remember This Cold",
+    "series_index": 20.0
+  },
+  {
+    "id": 78,
+    "series": "all that glitters is not gold",
+    "series_index": 8.0
+  },
+  {
+    "id": 80,
+    "series": "all that glitters is not gold",
+    "series_index": 9.0
+  },
+  {
+    "id": 82,
+    "series": "Journey of the Featherless",
+    "series_index": 2.0
+  },
+  {
+    "id": 86,
+    "series": "drabbles",
+    "series_index": 4.0
+  },
+  {
+    "id": 88,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 127.0
+  },
+  {
+    "id": 89,
+    "series": "Forms More Real Than Living Man",
+    "series_index": 1.0
+  },
+  {
+    "id": 91,
+    "series": "drabbles",
+    "series_index": 5.0
+  },
+  {
+    "id": 92,
+    "series": "drabbles",
+    "series_index": 6.0
+  },
+  {
+    "id": 94,
+    "series": "Commander Eliza Shepard",
+    "series_index": 11.0
+  },
+  {
+    "id": 95,
+    "series": "Tithe",
+    "series_index": 2.0
+  },
+  {
+    "id": 99,
+    "series": "mallverse",
+    "series_index": 57.0
+  },
+  {
+    "id": 104,
+    "series": "drabbles",
+    "series_index": 7.0
+  },
+  {
+    "id": 105,
+    "series": "Journey of the Featherless",
+    "series_index": 3.0
+  },
+  {
+    "id": 109,
+    "series": "drabbles",
+    "series_index": 8.0
+  },
+  {
+    "id": 115,
+    "series": "Diaries of Vicky Frankenstein",
+    "series_index": 1.0
+  },
+  {
+    "id": 121,
+    "series": "drabbles",
+    "series_index": 9.0
+  },
+  {
+    "id": 124,
+    "series": "mallverse",
+    "series_index": 58.0
+  },
+  {
+    "id": 125,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 16.0
+  },
+  {
+    "id": 128,
+    "series": "Remember This Cold",
+    "series_index": 11.0
+  },
+  {
+    "id": 133,
+    "series": "Black Sails Works",
+    "series_index": 4.0
+  },
+  {
+    "id": 134,
+    "series": "drabbles",
+    "series_index": 10.0
+  },
+  {
+    "id": 138,
+    "series": "People Are Hard",
+    "series_index": 3.0
+  },
+  {
+    "id": 140,
+    "series": "Commander Eliza Shepard",
+    "series_index": 7.0
+  },
+  {
+    "id": 144,
+    "series": "Remember This Cold",
+    "series_index": 58.0
+  },
+  {
+    "id": 147,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 121.0
+  },
+  {
+    "id": 148,
+    "series": "Happy Eruri Week!",
+    "series_index": 1.0
+  },
+  {
+    "id": 149,
+    "series": "Happy Eruri Week!",
+    "series_index": 2.0
+  },
+  {
+    "id": 150,
+    "series": "Happy Eruri Week!",
+    "series_index": 3.0
+  },
+  {
+    "id": 151,
+    "series": "Happy Eruri Week!",
+    "series_index": 4.0
+  },
+  {
+    "id": 152,
+    "series": "Supernatural Podfics",
+    "series_index": 32.0
+  },
+  {
+    "id": 153,
+    "series": "Happy Eruri Week!",
+    "series_index": 5.0
+  },
+  {
+    "id": 154,
+    "series": "Happy Eruri Week!",
+    "series_index": 6.0
+  },
+  {
+    "id": 155,
+    "series": "Happy Eruri Week!",
+    "series_index": 7.0
+  },
+  {
+    "id": 175,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 109.0
+  },
+  {
+    "id": 182,
+    "series": "Ghosts of All My Lovely Sins",
+    "series_index": 4.0
+  },
+  {
+    "id": 185,
+    "series": "Diaries of Vicky Frankenstein",
+    "series_index": 2.0
+  },
+  {
+    "id": 194,
+    "series": "DYNO",
+    "series_index": 1.0
+  },
+  {
+    "id": 196,
+    "series": "DYNO",
+    "series_index": 2.0
+  },
+  {
+    "id": 197,
+    "series": "DYNO",
+    "series_index": 3.0
+  },
+  {
+    "id": 198,
+    "series": "DYNO",
+    "series_index": 4.0
+  },
+  {
+    "id": 209,
+    "series": "Albus Dumbledore",
+    "series_index": 1.0
+  },
+  {
+    "id": 212,
+    "series": "Snape LDWS",
+    "series_index": 1.0
+  },
+  {
+    "id": 213,
+    "series": "Snape LDWS",
+    "series_index": 2.0
+  },
+  {
+    "id": 214,
+    "series": "Snape LDWS",
+    "series_index": 3.0
+  },
+  {
+    "id": 215,
+    "series": "Snape LDWS",
+    "series_index": 4.0
+  },
+  {
+    "id": 216,
+    "series": "Snape LDWS",
+    "series_index": 5.0
+  },
+  {
+    "id": 217,
+    "series": "Snape LDWS",
+    "series_index": 6.0
+  },
+  {
+    "id": 230,
+    "series": "Commander Eliza Shepard",
+    "series_index": 3.0
+  },
+  {
+    "id": 246,
+    "series": "drabbles",
+    "series_index": 11.0
+  },
+  {
+    "id": 247,
+    "series": "[to see you there]",
+    "series_index": 1.0
+  },
+  {
+    "id": 252,
+    "series": "The Usher",
+    "series_index": 8.0
+  },
+  {
+    "id": 253,
+    "series": "Gehenna",
+    "series_index": 7.0
+  },
+  {
+    "id": 254,
+    "series": "Black Sails Works",
+    "series_index": 3.0
+  },
+  {
+    "id": 256,
+    "series": "Black Sails Works",
+    "series_index": 2.0
+  },
+  {
+    "id": 261,
+    "series": "Remember This Cold",
+    "series_index": 62.0
+  },
+  {
+    "id": 268,
+    "series": "tumblr drabbles",
+    "series_index": 10.0
+  },
+  {
+    "id": 270,
+    "series": "Jane Foster Works",
+    "series_index": 5.0
+  },
+  {
+    "id": 272,
+    "series": "Commander Eliza Shepard",
+    "series_index": 5.0
+  },
+  {
+    "id": 277,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 124.0
+  },
+  {
+    "id": 280,
+    "series": "Remember This Cold",
+    "series_index": 6.0
+  },
+  {
+    "id": 284,
+    "series": "The Bright Side",
+    "series_index": 1.0
+  },
+  {
+    "id": 286,
+    "series": "Femslash February",
+    "series_index": 1.0
+  },
+  {
+    "id": 288,
+    "series": "Tapestries",
+    "series_index": 2.0
+  },
+  {
+    "id": 289,
+    "series": "Distant Shores and Voices",
+    "series_index": 11.0
+  },
+  {
+    "id": 292,
+    "series": "The Bright Side",
+    "series_index": 2.0
+  },
+  {
+    "id": 293,
+    "series": "Remember This Cold",
+    "series_index": 63.0
+  },
+  {
+    "id": 295,
+    "series": "Spreadsheet of love",
+    "series_index": 1.0
+  },
+  {
+    "id": 297,
+    "series": "Cryptozoology",
+    "series_index": 1.0
+  },
+  {
+    "id": 300,
+    "series": "I have some questions for the cosmonauts",
+    "series_index": 1.0
+  },
+  {
+    "id": 302,
+    "series": "drabbles",
+    "series_index": 12.0
+  },
+  {
+    "id": 305,
+    "series": "The Usher",
+    "series_index": 9.0
+  },
+  {
+    "id": 306,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 110.0
+  },
+  {
+    "id": 308,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 13.0
+  },
+  {
+    "id": 311,
+    "series": "The Bright Side",
+    "series_index": 3.0
+  },
+  {
+    "id": 313,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 111.0
+  },
+  {
+    "id": 314,
+    "series": "Remember This Cold",
+    "series_index": 64.0
+  },
+  {
+    "id": 315,
+    "series": "liminal spaces",
+    "series_index": 1.0
+  },
+  {
+    "id": 316,
+    "series": "Cryptozoology",
+    "series_index": 2.0
+  },
+  {
+    "id": 317,
+    "series": "drabbles",
+    "series_index": 13.0
+  },
+  {
+    "id": 319,
+    "series": "Distant Shores and Voices",
+    "series_index": 7.0
+  },
+  {
+    "id": 320,
+    "series": "Guitar and Video Games",
+    "series_index": 2.0
+  },
+  {
+    "id": 325,
+    "series": "the sun from shining",
+    "series_index": 2.0
+  },
+  {
+    "id": 326,
+    "series": "Guitar and Video Games",
+    "series_index": 3.0
+  },
+  {
+    "id": 327,
+    "series": "Earth 451",
+    "series_index": 1.0
+  },
+  {
+    "id": 328,
+    "series": "Hockey Boys",
+    "series_index": 1.0
+  },
+  {
+    "id": 329,
+    "series": "Hockey Boys",
+    "series_index": 3.0
+  },
+  {
+    "id": 331,
+    "series": "as long as you're mine",
+    "series_index": 1.0
+  },
+  {
+    "id": 332,
+    "series": "Earth 451",
+    "series_index": 2.0
+  },
+  {
+    "id": 334,
+    "series": "liminal spaces",
+    "series_index": 2.0
+  },
+  {
+    "id": 336,
+    "series": "mallverse",
+    "series_index": 59.0
+  },
+  {
+    "id": 343,
+    "series": "mallverse",
+    "series_index": 60.0
+  },
+  {
+    "id": 345,
+    "series": "I have some questions for the cosmonauts",
+    "series_index": 2.0
+  },
+  {
+    "id": 348,
+    "series": "The Usher",
+    "series_index": 10.0
+  },
+  {
+    "id": 352,
+    "series": "liminal spaces",
+    "series_index": 3.0
+  },
+  {
+    "id": 357,
+    "series": "Guitar and Video Games",
+    "series_index": 5.0
+  },
+  {
+    "id": 360,
+    "series": "Hockey Boys",
+    "series_index": 2.0
+  },
+  {
+    "id": 363,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 1.0
+  },
+  {
+    "id": 365,
+    "series": "mallverse",
+    "series_index": 61.0
+  },
+  {
+    "id": 378,
+    "series": "invisible machinery",
+    "series_index": 1.0
+  },
+  {
+    "id": 382,
+    "series": "all that glitters is not gold",
+    "series_index": 10.0
+  },
+  {
+    "id": 383,
+    "series": "Peasantverse",
+    "series_index": 6.0
+  },
+  {
+    "id": 389,
+    "series": "Tapestries",
+    "series_index": 3.0
+  },
+  {
+    "id": 407,
+    "series": "Earth 451",
+    "series_index": 3.0
+  },
+  {
+    "id": 414,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 2.0
+  },
+  {
+    "id": 423,
+    "series": "Pictures at an Exhibition",
+    "series_index": 2.0
+  },
+  {
+    "id": 424,
+    "series": "Commander Eliza Shepard",
+    "series_index": 4.0
+  },
+  {
+    "id": 428,
+    "series": "drabbles",
+    "series_index": 14.0
+  },
+  {
+    "id": 430,
+    "series": "drabbles",
+    "series_index": 15.0
+  },
+  {
+    "id": 431,
+    "series": "[to see you there]",
+    "series_index": 17.0
+  },
+  {
+    "id": 434,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 11.0
+  },
+  {
+    "id": 435,
+    "series": "drabbles",
+    "series_index": 16.0
+  },
+  {
+    "id": 436,
+    "series": "drabbles",
+    "series_index": 17.0
+  },
+  {
+    "id": 440,
+    "series": "drabbles",
+    "series_index": 18.0
+  },
+  {
+    "id": 441,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 105.0
+  },
+  {
+    "id": 442,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 3.0
+  },
+  {
+    "id": 443,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 4.0
+  },
+  {
+    "id": 444,
+    "series": "Remember This Cold",
+    "series_index": 19.0
+  },
+  {
+    "id": 445,
+    "series": "lattes and love songs",
+    "series_index": 1.0
+  },
+  {
+    "id": 449,
+    "series": "rewrite the stars",
+    "series_index": 1.0
+  },
+  {
+    "id": 451,
+    "series": "[to see you there]",
+    "series_index": 23.0
+  },
+  {
+    "id": 452,
+    "series": "Pepperony at Home",
+    "series_index": 1.0
+  },
+  {
+    "id": 453,
+    "series": "where some holy spectacle lies",
+    "series_index": 1.0
+  },
+  {
+    "id": 461,
+    "series": "untitled",
+    "series_index": 1.0
+  },
+  {
+    "id": 464,
+    "series": "lattes and love songs",
+    "series_index": 3.0
+  },
+  {
+    "id": 465,
+    "series": "Torn, Frayed and Mended",
+    "series_index": 1.0
+  },
+  {
+    "id": 466,
+    "series": "The Ruins of Babel",
+    "series_index": 1.0
+  },
+  {
+    "id": 467,
+    "series": "drabbles",
+    "series_index": 19.0
+  },
+  {
+    "id": 478,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 5.0
+  },
+  {
+    "id": 485,
+    "series": "untitled",
+    "series_index": 2.0
+  },
+  {
+    "id": 486,
+    "series": "Remember This Cold",
+    "series_index": 65.0
+  },
+  {
+    "id": 489,
+    "series": "Remember This Cold",
+    "series_index": 22.0
+  },
+  {
+    "id": 493,
+    "series": "Wicked Game(s)",
+    "series_index": 1.0
+  },
+  {
+    "id": 494,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 6.0
+  },
+  {
+    "id": 496,
+    "series": "where some holy spectacle lies",
+    "series_index": 2.0
+  },
+  {
+    "id": 498,
+    "series": "The Ruins of Babel",
+    "series_index": 2.0
+  },
+  {
+    "id": 501,
+    "series": "Remember This Cold",
+    "series_index": 66.0
+  },
+  {
+    "id": 502,
+    "series": "Remember This Cold",
+    "series_index": 24.0
+  },
+  {
+    "id": 503,
+    "series": "invisible machinery",
+    "series_index": 3.0
+  },
+  {
+    "id": 506,
+    "series": "canon compliant",
+    "series_index": 1.0
+  },
+  {
+    "id": 507,
+    "series": "twitter decisions",
+    "series_index": 1.0
+  },
+  {
+    "id": 509,
+    "series": "punchworld",
+    "series_index": 2.0
+  },
+  {
+    "id": 511,
+    "series": "flow morphia, slow",
+    "series_index": 1.0
+  },
+  {
+    "id": 512,
+    "series": "flow morphia, slow",
+    "series_index": 2.0
+  },
+  {
+    "id": 514,
+    "series": "where some holy spectacle lies",
+    "series_index": 3.0
+  },
+  {
+    "id": 517,
+    "series": "punchworld",
+    "series_index": 1.0
+  },
+  {
+    "id": 519,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 42.0
+  },
+  {
+    "id": 525,
+    "series": "change our prison to a sanctuary",
+    "series_index": 1.0
+  },
+  {
+    "id": 535,
+    "series": "[to see you there]",
+    "series_index": 28.0
+  },
+  {
+    "id": 545,
+    "series": "flow morphia, slow",
+    "series_index": 3.0
+  },
+  {
+    "id": 546,
+    "series": "Hockey Boys",
+    "series_index": 4.0
+  },
+  {
+    "id": 547,
+    "series": "flow morphia, slow",
+    "series_index": 4.0
+  },
+  {
+    "id": 550,
+    "series": "Stony Bingo 2018",
+    "series_index": 1.0
+  },
+  {
+    "id": 555,
+    "series": "Remember This Cold",
+    "series_index": 67.0
+  },
+  {
+    "id": 557,
+    "series": "drabbles",
+    "series_index": 20.0
+  },
+  {
+    "id": 559,
+    "series": "a dukedom large enough",
+    "series_index": 1.0
+  },
+  {
+    "id": 560,
+    "series": "untitled",
+    "series_index": 3.0
+  },
+  {
+    "id": 562,
+    "series": "Remember This Cold",
+    "series_index": 68.0
+  },
+  {
+    "id": 577,
+    "series": "Grim Tales",
+    "series_index": 4.0
+  },
+  {
+    "id": 583,
+    "series": "Take The Plan, Spin It Sideways",
+    "series_index": 2.0
+  },
+  {
+    "id": 584,
+    "series": "Casting of the Wine",
+    "series_index": 1.0
+  },
+  {
+    "id": 585,
+    "series": "untitled",
+    "series_index": 4.0
+  },
+  {
+    "id": 586,
+    "series": "Hawaii Five-O Steph Series",
+    "series_index": 1.0
+  },
+  {
+    "id": 589,
+    "series": "Grim Tales",
+    "series_index": 5.0
+  },
+  {
+    "id": 592,
+    "series": "Remember This Cold",
+    "series_index": 49.0
+  },
+  {
+    "id": 595,
+    "series": "[to see you there]",
+    "series_index": 14.0
+  },
+  {
+    "id": 596,
+    "series": "[to see you there]",
+    "series_index": 11.0
+  },
+  {
+    "id": 602,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 7.0
+  },
+  {
+    "id": 603,
+    "series": "Gehenna",
+    "series_index": 4.0
+  },
+  {
+    "id": 605,
+    "series": "mallverse",
+    "series_index": 62.0
+  },
+  {
+    "id": 613,
+    "series": "Casting of the Wine",
+    "series_index": 2.0
+  },
+  {
+    "id": 618,
+    "series": "Flipping Switches",
+    "series_index": 2.0
+  },
+  {
+    "id": 619,
+    "series": "Guitar and Video Games",
+    "series_index": 6.0
+  },
+  {
+    "id": 620,
+    "series": "invisible machinery",
+    "series_index": 2.0
+  },
+  {
+    "id": 622,
+    "series": "flow morphia, slow",
+    "series_index": 5.0
+  },
+  {
+    "id": 623,
+    "series": "mallverse",
+    "series_index": 63.0
+  },
+  {
+    "id": 624,
+    "series": "Earth 451",
+    "series_index": 4.0
+  },
+  {
+    "id": 632,
+    "series": "Thor Works",
+    "series_index": 7.0
+  },
+  {
+    "id": 633,
+    "series": "The Ruins of Babel",
+    "series_index": 4.0
+  },
+  {
+    "id": 634,
+    "series": "flow morphia, slow",
+    "series_index": 6.0
+  },
+  {
+    "id": 635,
+    "series": "Peter/Tony One-Shots",
+    "series_index": 1.0
+  },
+  {
+    "id": 637,
+    "series": "Peter/Tony One-Shots",
+    "series_index": 2.0
+  },
+  {
+    "id": 638,
+    "series": "Peter/Tony One-Shots",
+    "series_index": 3.0
+  },
+  {
+    "id": 639,
+    "series": "mallverse",
+    "series_index": 64.0
+  },
+  {
+    "id": 640,
+    "series": "mallverse",
+    "series_index": 65.0
+  },
+  {
+    "id": 641,
+    "series": "Remember This Cold",
+    "series_index": 69.0
+  },
+  {
+    "id": 648,
+    "series": "Author's Favorites",
+    "series_index": 11.0
+  },
+  {
+    "id": 649,
+    "series": "Black Sails Works",
+    "series_index": 1.0
+  },
+  {
+    "id": 650,
+    "series": "Tumblr Fics",
+    "series_index": 1.0
+  },
+  {
+    "id": 655,
+    "series": "drabbles",
+    "series_index": 1.0
+  },
+  {
+    "id": 662,
+    "series": "The Dead Revolutionaries Club",
+    "series_index": 1.0
+  },
+  {
+    "id": 667,
+    "series": "Where the Devil Don't Go",
+    "series_index": 1.0
+  },
+  {
+    "id": 670,
+    "series": "a dukedom large enough",
+    "series_index": 2.0
+  },
+  {
+    "id": 671,
+    "series": "Star Wars Works",
+    "series_index": 4.0
+  },
+  {
+    "id": 673,
+    "series": "Grim Tales",
+    "series_index": 6.0
+  },
+  {
+    "id": 683,
+    "series": "Innocent When You Dream",
+    "series_index": 1.0
+  },
+  {
+    "id": 685,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 128.0
+  },
+  {
+    "id": 689,
+    "series": "some kind of murder",
+    "series_index": 1.0
+  },
+  {
+    "id": 690,
+    "series": "take the mask off",
+    "series_index": 1.0
+  },
+  {
+    "id": 692,
+    "series": "layers of home",
+    "series_index": 1.0
+  },
+  {
+    "id": 696,
+    "series": "take the mask off",
+    "series_index": 2.0
+  },
+  {
+    "id": 699,
+    "series": "Hockey Boys",
+    "series_index": 5.0
+  },
+  {
+    "id": 703,
+    "series": "some kind of murder",
+    "series_index": 2.0
+  },
+  {
+    "id": 711,
+    "series": "figure my heart out",
+    "series_index": 1.0
+  },
+  {
+    "id": 712,
+    "series": "omnipresence",
+    "series_index": 2.0
+  },
+  {
+    "id": 713,
+    "series": "The Dead Revolutionaries Club",
+    "series_index": 2.0
+  },
+  {
+    "id": 717,
+    "series": "Wicked Game(s)",
+    "series_index": 2.0
+  },
+  {
+    "id": 720,
+    "series": "Author's Favorites",
+    "series_index": 12.0
+  },
+  {
+    "id": 721,
+    "series": "change our prison to a sanctuary",
+    "series_index": 2.0
+  },
+  {
+    "id": 724,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 1.0
+  },
+  {
+    "id": 727,
+    "series": "Tumblr Fics",
+    "series_index": 2.0
+  },
+  {
+    "id": 728,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 2.0
+  },
+  {
+    "id": 748,
+    "series": "untitled",
+    "series_index": 5.0
+  },
+  {
+    "id": 750,
+    "series": "Stony Bingo 2018",
+    "series_index": 2.0
+  },
+  {
+    "id": 752,
+    "series": "Stony Bingo 2018",
+    "series_index": 3.0
+  },
+  {
+    "id": 753,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 129.0
+  },
+  {
+    "id": 756,
+    "series": "Dimension Hopping Knights",
+    "series_index": 1.0
+  },
+  {
+    "id": 757,
+    "series": "Dimension Hopping Knights",
+    "series_index": 2.0
+  },
+  {
+    "id": 759,
+    "series": "Stony Bingo 2018",
+    "series_index": 6.0
+  },
+  {
+    "id": 762,
+    "series": "Distant Shores and Voices",
+    "series_index": 9.0
+  },
+  {
+    "id": 765,
+    "series": "Hawaii Five-O Steph Series",
+    "series_index": 2.0
+  },
+  {
+    "id": 767,
+    "series": "Where the Devil Don't Go",
+    "series_index": 4.0
+  },
+  {
+    "id": 769,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 3.0
+  },
+  {
+    "id": 770,
+    "series": "twitter decisions",
+    "series_index": 3.0
+  },
+  {
+    "id": 771,
+    "series": "omnipresence",
+    "series_index": 3.0
+  },
+  {
+    "id": 772,
+    "series": "Pepperony at Home",
+    "series_index": 2.0
+  },
+  {
+    "id": 776,
+    "series": "punchworld",
+    "series_index": 3.0
+  },
+  {
+    "id": 779,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 4.0
+  },
+  {
+    "id": 780,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 5.0
+  },
+  {
+    "id": 781,
+    "series": "Diaries of Vicky Frankenstein",
+    "series_index": 3.0
+  },
+  {
+    "id": 782,
+    "series": "The Usher",
+    "series_index": 11.0
+  },
+  {
+    "id": 788,
+    "series": "Gods and Monsters AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 794,
+    "series": "Guitar and Video Games",
+    "series_index": 7.0
+  },
+  {
+    "id": 796,
+    "series": "Author's Favorites",
+    "series_index": 8.0
+  },
+  {
+    "id": 802,
+    "series": "Tapestries",
+    "series_index": 4.0
+  },
+  {
+    "id": 803,
+    "series": "Author's Favorites",
+    "series_index": 9.0
+  },
+  {
+    "id": 806,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 6.0
+  },
+  {
+    "id": 807,
+    "series": "Thor Works",
+    "series_index": 10.0
+  },
+  {
+    "id": 812,
+    "series": "Thor Works",
+    "series_index": 9.0
+  },
+  {
+    "id": 821,
+    "series": "Remember This Cold",
+    "series_index": 70.0
+  },
+  {
+    "id": 823,
+    "series": "Fragile Machines",
+    "series_index": 1.0
+  },
+  {
+    "id": 827,
+    "series": "kinktober 2018",
+    "series_index": 1.0
+  },
+  {
+    "id": 828,
+    "series": "kinktober 2018",
+    "series_index": 2.0
+  },
+  {
+    "id": 829,
+    "series": "Amerihawk Week 2018",
+    "series_index": 1.0
+  },
+  {
+    "id": 830,
+    "series": "kinktober 2018",
+    "series_index": 3.0
+  },
+  {
+    "id": 831,
+    "series": "Amerihawk Week 2018",
+    "series_index": 2.0
+  },
+  {
+    "id": 836,
+    "series": "Amerihawk Week 2018",
+    "series_index": 3.0
+  },
+  {
+    "id": 838,
+    "series": "Amerihawk Week 2018",
+    "series_index": 4.0
+  },
+  {
+    "id": 840,
+    "series": "Amerihawk Week 2018",
+    "series_index": 5.0
+  },
+  {
+    "id": 842,
+    "series": "Amerihawk Week 2018",
+    "series_index": 6.0
+  },
+  {
+    "id": 847,
+    "series": "season twelve snippets",
+    "series_index": 1.0
+  },
+  {
+    "id": 850,
+    "series": "Venom Works",
+    "series_index": 2.0
+  },
+  {
+    "id": 857,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 7.0
+  },
+  {
+    "id": 858,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 8.0
+  },
+  {
+    "id": 866,
+    "series": "this is love in the modern way",
+    "series_index": 1.0
+  },
+  {
+    "id": 868,
+    "series": "Can't Have WangXian Without Kink",
+    "series_index": 1.0
+  },
+  {
+    "id": 869,
+    "series": "kinktober 2018",
+    "series_index": 4.0
+  },
+  {
+    "id": 885,
+    "series": "this is love in the modern way",
+    "series_index": 2.0
+  },
+  {
+    "id": 887,
+    "series": "Tumblr Fics",
+    "series_index": 3.0
+  },
+  {
+    "id": 889,
+    "series": "Remember This Cold",
+    "series_index": 25.0
+  },
+  {
+    "id": 897,
+    "series": "Venom Works",
+    "series_index": 1.0
+  },
+  {
+    "id": 908,
+    "series": "Where the Devil Don't Go",
+    "series_index": 5.0
+  },
+  {
+    "id": 909,
+    "series": "A Dark Desert Highway",
+    "series_index": 1.0
+  },
+  {
+    "id": 913,
+    "series": "punchworld",
+    "series_index": 4.0
+  },
+  {
+    "id": 918,
+    "series": "your blue-eyed boys",
+    "series_index": 1.0
+  },
+  {
+    "id": 920,
+    "series": "your blue-eyed boys",
+    "series_index": 2.0
+  },
+  {
+    "id": 921,
+    "series": "your blue-eyed boys",
+    "series_index": 3.0
+  },
+  {
+    "id": 922,
+    "series": "your blue-eyed boys",
+    "series_index": 4.0
+  },
+  {
+    "id": 923,
+    "series": "A Greater Compliment",
+    "series_index": 1.0
+  },
+  {
+    "id": 924,
+    "series": "A Greater Compliment",
+    "series_index": 3.0
+  },
+  {
+    "id": 926,
+    "series": "A Greater Compliment",
+    "series_index": 9.0
+  },
+  {
+    "id": 927,
+    "series": "A Greater Compliment",
+    "series_index": 2.0
+  },
+  {
+    "id": 928,
+    "series": "A Greater Compliment",
+    "series_index": 4.0
+  },
+  {
+    "id": 929,
+    "series": "A Greater Compliment",
+    "series_index": 5.0
+  },
+  {
+    "id": 930,
+    "series": "A Greater Compliment",
+    "series_index": 7.0
+  },
+  {
+    "id": 931,
+    "series": "A Greater Compliment",
+    "series_index": 8.0
+  },
+  {
+    "id": 932,
+    "series": "A Greater Compliment",
+    "series_index": 10.0
+  },
+  {
+    "id": 933,
+    "series": "A Greater Compliment",
+    "series_index": 11.0
+  },
+  {
+    "id": 934,
+    "series": "A Greater Compliment",
+    "series_index": 12.0
+  },
+  {
+    "id": 935,
+    "series": "A Greater Compliment",
+    "series_index": 13.0
+  },
+  {
+    "id": 941,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 942,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 2.0
+  },
+  {
+    "id": 943,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 3.0
+  },
+  {
+    "id": 944,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 4.0
+  },
+  {
+    "id": 945,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 5.0
+  },
+  {
+    "id": 946,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 6.0
+  },
+  {
+    "id": 947,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 7.0
+  },
+  {
+    "id": 948,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 8.0
+  },
+  {
+    "id": 967,
+    "series": "Remember This Cold",
+    "series_index": 27.0
+  },
+  {
+    "id": 968,
+    "series": "untitled college bdsm au",
+    "series_index": 1.0
+  },
+  {
+    "id": 974,
+    "series": "holding up the sky",
+    "series_index": 1.0
+  },
+  {
+    "id": 982,
+    "series": "Where the Devil Don't Go",
+    "series_index": 6.0
+  },
+  {
+    "id": 983,
+    "series": "(New) VC missing chapters",
+    "series_index": 1.0
+  },
+  {
+    "id": 984,
+    "series": "into something rich and strange",
+    "series_index": 2.0
+  },
+  {
+    "id": 989,
+    "series": "A Dark Desert Highway",
+    "series_index": 2.0
+  },
+  {
+    "id": 990,
+    "series": "Gods and Monsters AU",
+    "series_index": 2.0
+  },
+  {
+    "id": 995,
+    "series": "Remember This Cold",
+    "series_index": 46.0
+  },
+  {
+    "id": 1004,
+    "series": "Remember This Cold",
+    "series_index": 71.0
+  },
+  {
+    "id": 1022,
+    "series": "Guitar and Video Games",
+    "series_index": 8.0
+  },
+  {
+    "id": 1028,
+    "series": "only fools fall",
+    "series_index": 1.0
+  },
+  {
+    "id": 1031,
+    "series": "Grim Tales",
+    "series_index": 7.0
+  },
+  {
+    "id": 1036,
+    "series": "A Greater Compliment",
+    "series_index": 6.0
+  },
+  {
+    "id": 1044,
+    "series": "Infinite Coffee and Protection Detail",
+    "series_index": 1.0
+  },
+  {
+    "id": 1056,
+    "series": "SV Wishes",
+    "series_index": 1.0
+  },
+  {
+    "id": 1057,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 12.0
+  },
+  {
+    "id": 1066,
+    "series": "[to see you there]",
+    "series_index": 2.0
+  },
+  {
+    "id": 1068,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 130.0
+  },
+  {
+    "id": 1069,
+    "series": "[to see you there]",
+    "series_index": 30.0
+  },
+  {
+    "id": 1075,
+    "series": "Serrated Verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1076,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 9.0
+  },
+  {
+    "id": 1077,
+    "series": "i'll be coming for your love (okay?)",
+    "series_index": 10.0
+  },
+  {
+    "id": 1086,
+    "series": "drabbles",
+    "series_index": 21.0
+  },
+  {
+    "id": 1089,
+    "series": "In the Summer All The Lights Would Shine/Hello Kitty Microwave 'Verse:",
+    "series_index": 1.0
+  },
+  {
+    "id": 1090,
+    "series": "The Ruins of Babel",
+    "series_index": 3.0
+  },
+  {
+    "id": 1093,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 8.0
+  },
+  {
+    "id": 1094,
+    "series": "season twelve snippets",
+    "series_index": 2.0
+  },
+  {
+    "id": 1102,
+    "series": "Dual Cultivation",
+    "series_index": 1.0
+  },
+  {
+    "id": 1103,
+    "series": "Commander Eliza Shepard",
+    "series_index": 1.0
+  },
+  {
+    "id": 1108,
+    "series": "For Keeps",
+    "series_index": 1.0
+  },
+  {
+    "id": 1110,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 1.0
+  },
+  {
+    "id": 1112,
+    "series": "only fools fall",
+    "series_index": 2.0
+  },
+  {
+    "id": 1114,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 2.0
+  },
+  {
+    "id": 1115,
+    "series": "Dual Cultivation",
+    "series_index": 2.0
+  },
+  {
+    "id": 1116,
+    "series": "Remember This Cold",
+    "series_index": 23.0
+  },
+  {
+    "id": 1117,
+    "series": "Love From a Gurney",
+    "series_index": 1.0
+  },
+  {
+    "id": 1118,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 3.0
+  },
+  {
+    "id": 1125,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 4.0
+  },
+  {
+    "id": 1126,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 5.0
+  },
+  {
+    "id": 1132,
+    "series": "The dangerous book for boys.",
+    "series_index": 1.0
+  },
+  {
+    "id": 1133,
+    "series": "The dangerous book for boys.",
+    "series_index": 2.0
+  },
+  {
+    "id": 1137,
+    "series": "Monsters.",
+    "series_index": 1.0
+  },
+  {
+    "id": 1138,
+    "series": "Monsters.",
+    "series_index": 2.0
+  },
+  {
+    "id": 1146,
+    "series": "The Masterverse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1147,
+    "series": "The Masterverse",
+    "series_index": 2.0
+  },
+  {
+    "id": 1148,
+    "series": "The Masterverse",
+    "series_index": 3.0
+  },
+  {
+    "id": 1149,
+    "series": "The Masterverse",
+    "series_index": 4.0
+  },
+  {
+    "id": 1155,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 6.0
+  },
+  {
+    "id": 1158,
+    "series": "Skinned knees 'verse.",
+    "series_index": 1.0
+  },
+  {
+    "id": 1159,
+    "series": "Skinned knees 'verse.",
+    "series_index": 2.0
+  },
+  {
+    "id": 1160,
+    "series": "Skinned knees 'verse.",
+    "series_index": 3.0
+  },
+  {
+    "id": 1170,
+    "series": "Dancers/Letters",
+    "series_index": 1.0
+  },
+  {
+    "id": 1173,
+    "series": "The Masterverse",
+    "series_index": 5.0
+  },
+  {
+    "id": 1176,
+    "series": "Peace in our time/Maturity",
+    "series_index": 1.0
+  },
+  {
+    "id": 1177,
+    "series": "[to see you there]",
+    "series_index": 31.0
+  },
+  {
+    "id": 1178,
+    "series": "Peace in our time/Maturity",
+    "series_index": 2.0
+  },
+  {
+    "id": 1180,
+    "series": "The Masterverse",
+    "series_index": 6.0
+  },
+  {
+    "id": 1186,
+    "series": "Love From a Gurney",
+    "series_index": 3.0
+  },
+  {
+    "id": 1190,
+    "series": "come morning light",
+    "series_index": 1.0
+  },
+  {
+    "id": 1194,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 7.0
+  },
+  {
+    "id": 1203,
+    "series": "little beasts",
+    "series_index": 91.0
+  },
+  {
+    "id": 1208,
+    "series": "little beasts",
+    "series_index": 90.0
+  },
+  {
+    "id": 1209,
+    "series": "Strange Nights, Stranger Journeys",
+    "series_index": 3.0
+  },
+  {
+    "id": 1211,
+    "series": "A Greater Compliment",
+    "series_index": 15.0
+  },
+  {
+    "id": 1212,
+    "series": "A Dark Desert Highway",
+    "series_index": 3.0
+  },
+  {
+    "id": 1213,
+    "series": "An Agreeable Companion",
+    "series_index": 4.0
+  },
+  {
+    "id": 1215,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 8.0
+  },
+  {
+    "id": 1220,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 9.0
+  },
+  {
+    "id": 1222,
+    "series": "Remember This Cold",
+    "series_index": 72.0
+  },
+  {
+    "id": 1226,
+    "series": "Today, your barista 'verse",
+    "series_index": 4.0
+  },
+  {
+    "id": 1235,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 10.0
+  },
+  {
+    "id": 1240,
+    "series": "Ar lath'an: This Place of Love",
+    "series_index": 11.0
+  },
+  {
+    "id": 1244,
+    "series": "Notes on Thedas",
+    "series_index": 2.0
+  },
+  {
+    "id": 1245,
+    "series": "Notes on Thedas",
+    "series_index": 3.0
+  },
+  {
+    "id": 1246,
+    "series": "Notes on Thedas",
+    "series_index": 4.0
+  },
+  {
+    "id": 1249,
+    "series": "Fruit Punch Lips/Tar Black Soul",
+    "series_index": 1.0
+  },
+  {
+    "id": 1258,
+    "series": "Love From a Gurney",
+    "series_index": 2.0
+  },
+  {
+    "id": 1264,
+    "series": "Wen Mao",
+    "series_index": 1.0
+  },
+  {
+    "id": 1266,
+    "series": "Love From a Gurney",
+    "series_index": 4.0
+  },
+  {
+    "id": 1267,
+    "series": "Love From a Gurney",
+    "series_index": 5.0
+  },
+  {
+    "id": 1268,
+    "series": "Author's Favorites",
+    "series_index": 15.0
+  },
+  {
+    "id": 1269,
+    "series": "Fruit Punch Lips/Tar Black Soul",
+    "series_index": 2.0
+  },
+  {
+    "id": 1274,
+    "series": "like the setting sun",
+    "series_index": 1.0
+  },
+  {
+    "id": 1282,
+    "series": "untitled",
+    "series_index": 6.0
+  },
+  {
+    "id": 1290,
+    "series": "Distant Shores and Voices",
+    "series_index": 5.0
+  },
+  {
+    "id": 1299,
+    "series": "Author's Favorites",
+    "series_index": 14.0
+  },
+  {
+    "id": 1300,
+    "series": "unless we realize",
+    "series_index": 1.0
+  },
+  {
+    "id": 1307,
+    "series": "Remember This Cold",
+    "series_index": 26.0
+  },
+  {
+    "id": 1311,
+    "series": "shut your mouth, baby (stand and deliver)",
+    "series_index": 1.0
+  },
+  {
+    "id": 1313,
+    "series": "a little to the left",
+    "series_index": 1.0
+  },
+  {
+    "id": 1315,
+    "series": "i don't say no /and you don't say no (the carmen sandiego au)",
+    "series_index": 1.0
+  },
+  {
+    "id": 1318,
+    "series": "i don't say no /and you don't say no (the carmen sandiego au)",
+    "series_index": 2.0
+  },
+  {
+    "id": 1325,
+    "series": "Into the Binghe Verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1327,
+    "series": "Walking Clothes Universe",
+    "series_index": 2.0
+  },
+  {
+    "id": 1346,
+    "series": "Westie's Art",
+    "series_index": 1.0
+  },
+  {
+    "id": 1348,
+    "series": "songs of love and devotion",
+    "series_index": 1.0
+  },
+  {
+    "id": 1350,
+    "series": "all your love and your longing",
+    "series_index": 1.0
+  },
+  {
+    "id": 1369,
+    "series": "all your love and your longing",
+    "series_index": 2.0
+  },
+  {
+    "id": 1375,
+    "series": "Odyssey",
+    "series_index": 7.0
+  },
+  {
+    "id": 1376,
+    "series": "like the setting sun",
+    "series_index": 2.0
+  },
+  {
+    "id": 1377,
+    "series": "intricate rituals",
+    "series_index": 1.0
+  },
+  {
+    "id": 1378,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 9.0
+  },
+  {
+    "id": 1380,
+    "series": "shut your mouth, baby (stand and deliver)",
+    "series_index": 2.0
+  },
+  {
+    "id": 1389,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 9.0
+  },
+  {
+    "id": 1390,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 10.0
+  },
+  {
+    "id": 1391,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 4.0
+  },
+  {
+    "id": 1392,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 5.0
+  },
+  {
+    "id": 1393,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 8.0
+  },
+  {
+    "id": 1394,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 7.0
+  },
+  {
+    "id": 1395,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 16.0
+  },
+  {
+    "id": 1396,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 18.0
+  },
+  {
+    "id": 1397,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 21.0
+  },
+  {
+    "id": 1398,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 23.0
+  },
+  {
+    "id": 1399,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 25.0
+  },
+  {
+    "id": 1400,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 24.0
+  },
+  {
+    "id": 1401,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 37.0
+  },
+  {
+    "id": 1402,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 26.0
+  },
+  {
+    "id": 1404,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 27.0
+  },
+  {
+    "id": 1405,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 36.0
+  },
+  {
+    "id": 1409,
+    "series": "omnipresence",
+    "series_index": 1.0
+  },
+  {
+    "id": 1411,
+    "series": "Guitar and Video Games",
+    "series_index": 1.0
+  },
+  {
+    "id": 1419,
+    "series": "Four Ducks on a Pond",
+    "series_index": 1.0
+  },
+  {
+    "id": 1424,
+    "series": "i don't say no /and you don't say no (the carmen sandiego au)",
+    "series_index": 3.0
+  },
+  {
+    "id": 1427,
+    "series": "author's mdzs faves",
+    "series_index": 8.0
+  },
+  {
+    "id": 1432,
+    "series": "Where the Devil Don't Go",
+    "series_index": 8.0
+  },
+  {
+    "id": 1436,
+    "series": "tcgf character studies ft. daoism(?)",
+    "series_index": 2.0
+  },
+  {
+    "id": 1441,
+    "series": "Where the Devil Don't Go",
+    "series_index": 7.0
+  },
+  {
+    "id": 1452,
+    "series": "XiYao Week 2019",
+    "series_index": 5.0
+  },
+  {
+    "id": 1453,
+    "series": "kinktober 2019",
+    "series_index": 1.0
+  },
+  {
+    "id": 1458,
+    "series": "Absolutely True Story-verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1466,
+    "series": "little beasts",
+    "series_index": 93.0
+  },
+  {
+    "id": 1470,
+    "series": "The Grand Unified Theory of Sh\u011bn Q\u012bngqi\u016b",
+    "series_index": 1.0
+  },
+  {
+    "id": 1481,
+    "series": "Where the Devil Don't Go",
+    "series_index": 9.0
+  },
+  {
+    "id": 1486,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 14.0
+  },
+  {
+    "id": 1488,
+    "series": "little beasts",
+    "series_index": 95.0
+  },
+  {
+    "id": 1493,
+    "series": "Atlas ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 1500,
+    "series": "BDSM AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 1501,
+    "series": "little beasts",
+    "series_index": 98.0
+  },
+  {
+    "id": 1502,
+    "series": "little beasts",
+    "series_index": 99.0
+  },
+  {
+    "id": 1506,
+    "series": "i feel god in this kentucky tonight",
+    "series_index": 1.0
+  },
+  {
+    "id": 1514,
+    "series": "Where the Devil Don't Go",
+    "series_index": 10.0
+  },
+  {
+    "id": 1522,
+    "series": "We are a woven thread, find the strand",
+    "series_index": 1.0
+  },
+  {
+    "id": 1527,
+    "series": "Where the Devil Don't Go",
+    "series_index": 2.0
+  },
+  {
+    "id": 1536,
+    "series": "to descend from mountaintops | \u5fc5\u987b\u4e0b\u5c71",
+    "series_index": 1.0
+  },
+  {
+    "id": 1537,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 10.0
+  },
+  {
+    "id": 1539,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 15.0
+  },
+  {
+    "id": 1540,
+    "series": "Your Life Again, Your Life Anew",
+    "series_index": 1.0
+  },
+  {
+    "id": 1544,
+    "series": "it's just like we were meant to be",
+    "series_index": 3.0
+  },
+  {
+    "id": 1545,
+    "series": "untitled",
+    "series_index": 7.0
+  },
+  {
+    "id": 1548,
+    "series": "By Degrees",
+    "series_index": 1.0
+  },
+  {
+    "id": 1551,
+    "series": "Author's Favorites",
+    "series_index": 6.0
+  },
+  {
+    "id": 1559,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 11.0
+  },
+  {
+    "id": 1561,
+    "series": "A Greater Compliment",
+    "series_index": 14.0
+  },
+  {
+    "id": 1570,
+    "series": "A Civil Combpaign",
+    "series_index": 1.0
+  },
+  {
+    "id": 1573,
+    "series": "Four Ducks on a Pond",
+    "series_index": 2.0
+  },
+  {
+    "id": 1576,
+    "series": "the yunmeng accords",
+    "series_index": 2.0
+  },
+  {
+    "id": 1579,
+    "series": "from season to season",
+    "series_index": 4.0
+  },
+  {
+    "id": 1582,
+    "series": "Remember This Cold",
+    "series_index": 12.0
+  },
+  {
+    "id": 1583,
+    "series": "Wen Mao",
+    "series_index": 2.0
+  },
+  {
+    "id": 1587,
+    "series": "Every Happily Ever After Is Bought By Someone Else's Tragedy",
+    "series_index": 1.0
+  },
+  {
+    "id": 1588,
+    "series": "Yeehaw it's werewolf pornos",
+    "series_index": 2.0
+  },
+  {
+    "id": 1589,
+    "series": "A Civil Combpaign",
+    "series_index": 2.0
+  },
+  {
+    "id": 1602,
+    "series": "Where the Devil Don't Go",
+    "series_index": 11.0
+  },
+  {
+    "id": 1604,
+    "series": "Marriage Principles",
+    "series_index": 1.0
+  },
+  {
+    "id": 1607,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 19.0
+  },
+  {
+    "id": 1608,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 39.0
+  },
+  {
+    "id": 1609,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 28.0
+  },
+  {
+    "id": 1610,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 22.0
+  },
+  {
+    "id": 1611,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 29.0
+  },
+  {
+    "id": 1612,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 30.0
+  },
+  {
+    "id": 1616,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 43.0
+  },
+  {
+    "id": 1617,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 44.0
+  },
+  {
+    "id": 1618,
+    "series": "MDZS-Dissecting, Zealous Shimei",
+    "series_index": 1.0
+  },
+  {
+    "id": 1619,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 45.0
+  },
+  {
+    "id": 1620,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 48.0
+  },
+  {
+    "id": 1621,
+    "series": "like the setting sun",
+    "series_index": 3.0
+  },
+  {
+    "id": 1622,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 49.0
+  },
+  {
+    "id": 1628,
+    "series": "Guitar and Video Games",
+    "series_index": 9.0
+  },
+  {
+    "id": 1632,
+    "series": "no new age",
+    "series_index": 1.0
+  },
+  {
+    "id": 1634,
+    "series": "Unclean Realm",
+    "series_index": 4.0
+  },
+  {
+    "id": 1637,
+    "series": "Wangji Week 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 1639,
+    "series": "aizuchi",
+    "series_index": 1.0
+  },
+  {
+    "id": 1643,
+    "series": "Remember This Cold",
+    "series_index": 73.0
+  },
+  {
+    "id": 1649,
+    "series": "from season to season",
+    "series_index": 3.0
+  },
+  {
+    "id": 1654,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 52.0
+  },
+  {
+    "id": 1658,
+    "series": "Distress Call 'Verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1662,
+    "series": "Westie's Art",
+    "series_index": 2.0
+  },
+  {
+    "id": 1669,
+    "series": "my gangbang brings all the sluts to the yard",
+    "series_index": 1.0
+  },
+  {
+    "id": 1670,
+    "series": "Through the looking-glass: Naruto genderswap!AU",
+    "series_index": 13.0
+  },
+  {
+    "id": 1673,
+    "series": "The night sky is vast and wide",
+    "series_index": 1.0
+  },
+  {
+    "id": 1674,
+    "series": "MDZS-Dissecting, Zealous Shimei",
+    "series_index": 2.0
+  },
+  {
+    "id": 1684,
+    "series": "the devil is the space between two men",
+    "series_index": 1.0
+  },
+  {
+    "id": 1685,
+    "series": "set your old heart free",
+    "series_index": 3.0
+  },
+  {
+    "id": 1691,
+    "series": "Meets the Eye",
+    "series_index": 1.0
+  },
+  {
+    "id": 1696,
+    "series": "strict machine",
+    "series_index": 1.0
+  },
+  {
+    "id": 1700,
+    "series": "strict machine",
+    "series_index": 2.0
+  },
+  {
+    "id": 1706,
+    "series": "The Long Slow Yes Job",
+    "series_index": 1.0
+  },
+  {
+    "id": 1723,
+    "series": "The Same Moon Shines",
+    "series_index": 1.0
+  },
+  {
+    "id": 1724,
+    "series": "Where the Devil Don't Go",
+    "series_index": 3.0
+  },
+  {
+    "id": 1729,
+    "series": "in case you should ever ask",
+    "series_index": 1.0
+  },
+  {
+    "id": 1731,
+    "series": "Soft and Pretty",
+    "series_index": 1.0
+  },
+  {
+    "id": 1732,
+    "series": "Twelve Moons and a Fortnight Verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1733,
+    "series": "Strange Nights, Stranger Journeys",
+    "series_index": 1.0
+  },
+  {
+    "id": 1734,
+    "series": "Strange Nights, Stranger Journeys",
+    "series_index": 2.0
+  },
+  {
+    "id": 1737,
+    "series": "Demarcation Line",
+    "series_index": 1.0
+  },
+  {
+    "id": 1738,
+    "series": "Commissions",
+    "series_index": 1.0
+  },
+  {
+    "id": 1742,
+    "series": "Kings County",
+    "series_index": 1.0
+  },
+  {
+    "id": 1746,
+    "series": "Distant Shores and Voices",
+    "series_index": 16.0
+  },
+  {
+    "id": 1748,
+    "series": "Demarcation Line",
+    "series_index": 2.0
+  },
+  {
+    "id": 1749,
+    "series": "Absolutely True Story-verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 1756,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 53.0
+  },
+  {
+    "id": 1759,
+    "series": "Distress Call 'Verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 1763,
+    "series": "Xichen Week 2020",
+    "series_index": 1.0
+  },
+  {
+    "id": 1765,
+    "series": "the devil is the space between two men",
+    "series_index": 2.0
+  },
+  {
+    "id": 1768,
+    "series": "Xichen Week 2020",
+    "series_index": 2.0
+  },
+  {
+    "id": 1769,
+    "series": "The Long Slow Yes Job",
+    "series_index": 2.0
+  },
+  {
+    "id": 1772,
+    "series": "Author's Favourites",
+    "series_index": 17.0
+  },
+  {
+    "id": 1774,
+    "series": "Remember This Cold",
+    "series_index": 74.0
+  },
+  {
+    "id": 1780,
+    "series": "stand and face me, my love, and scatter the grace in your eyes",
+    "series_index": 1.0
+  },
+  {
+    "id": 1782,
+    "series": "the yunmeng accords",
+    "series_index": 3.0
+  },
+  {
+    "id": 1783,
+    "series": "Xichen Week 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 1788,
+    "series": "House 'verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1791,
+    "series": "The Long Slow Yes Job",
+    "series_index": 3.0
+  },
+  {
+    "id": 1792,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 54.0
+  },
+  {
+    "id": 1803,
+    "series": "monster 'verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 1806,
+    "series": "Cataractae",
+    "series_index": 1.0
+  },
+  {
+    "id": 1812,
+    "series": "in case you should ever ask",
+    "series_index": 2.0
+  },
+  {
+    "id": 1813,
+    "series": "The Long Slow Yes Job",
+    "series_index": 4.0
+  },
+  {
+    "id": 1818,
+    "series": "Meets the Eye",
+    "series_index": 2.0
+  },
+  {
+    "id": 1821,
+    "series": "Guitar and Video Games",
+    "series_index": 4.0
+  },
+  {
+    "id": 1827,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 1.0
+  },
+  {
+    "id": 1829,
+    "series": "all the depths of us",
+    "series_index": 1.0
+  },
+  {
+    "id": 1830,
+    "series": "Eyes Open",
+    "series_index": 3.0
+  },
+  {
+    "id": 1836,
+    "series": "To the Ends of the Earth",
+    "series_index": 1.0
+  },
+  {
+    "id": 1837,
+    "series": "Your Life Again, Your Life Anew",
+    "series_index": 2.0
+  },
+  {
+    "id": 1839,
+    "series": "To the Ends of the Earth",
+    "series_index": 2.0
+  },
+  {
+    "id": 1840,
+    "series": "A Troublesome Charge",
+    "series_index": 2.0
+  },
+  {
+    "id": 1843,
+    "series": "monster 'verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 1844,
+    "series": "like the setting sun",
+    "series_index": 4.0
+  },
+  {
+    "id": 1846,
+    "series": "The Long Slow Yes Job",
+    "series_index": 5.0
+  },
+  {
+    "id": 1849,
+    "series": "To the Ends of the Earth",
+    "series_index": 3.0
+  },
+  {
+    "id": 1858,
+    "series": "Eyes Open",
+    "series_index": 1.0
+  },
+  {
+    "id": 1859,
+    "series": "Soft and Pretty",
+    "series_index": 2.0
+  },
+  {
+    "id": 1860,
+    "series": "Eyes Open",
+    "series_index": 2.0
+  },
+  {
+    "id": 1867,
+    "series": "The Long Slow Yes Job",
+    "series_index": 6.0
+  },
+  {
+    "id": 1868,
+    "series": "sxx configurations",
+    "series_index": 2.0
+  },
+  {
+    "id": 1870,
+    "series": "epochenonsense",
+    "series_index": 3.0
+  },
+  {
+    "id": 1871,
+    "series": "circling like vultures",
+    "series_index": 1.0
+  },
+  {
+    "id": 1875,
+    "series": "To the Ends of the Earth",
+    "series_index": 4.0
+  },
+  {
+    "id": 1876,
+    "series": "as long as you're mine",
+    "series_index": 2.0
+  },
+  {
+    "id": 1879,
+    "series": "Alchemical Processes",
+    "series_index": 1.0
+  },
+  {
+    "id": 1880,
+    "series": "tiny awoos",
+    "series_index": 1.0
+  },
+  {
+    "id": 1892,
+    "series": "histories",
+    "series_index": 1.0
+  },
+  {
+    "id": 1894,
+    "series": "Just Meng Yao Things",
+    "series_index": 1.0
+  },
+  {
+    "id": 1895,
+    "series": "The Long Slow Yes Job",
+    "series_index": 7.0
+  },
+  {
+    "id": 1898,
+    "series": "Yunmeng Spice",
+    "series_index": 1.0
+  },
+  {
+    "id": 1900,
+    "series": "sxx configurations",
+    "series_index": 1.0
+  },
+  {
+    "id": 1905,
+    "series": "Cataractae",
+    "series_index": 2.0
+  },
+  {
+    "id": 1909,
+    "series": "Alchemical Processes",
+    "series_index": 2.0
+  },
+  {
+    "id": 1911,
+    "series": "looking back",
+    "series_index": 1.0
+  },
+  {
+    "id": 1915,
+    "series": "tiny awoos",
+    "series_index": 2.0
+  },
+  {
+    "id": 1916,
+    "series": "To the Ends of the Earth",
+    "series_index": 6.0
+  },
+  {
+    "id": 1917,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 3.0
+  },
+  {
+    "id": 1919,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 55.0
+  },
+  {
+    "id": 1921,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 50.0
+  },
+  {
+    "id": 1922,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 58.0
+  },
+  {
+    "id": 1925,
+    "series": "the dictionary of obscure sorrows",
+    "series_index": 9.0
+  },
+  {
+    "id": 1928,
+    "series": "pathologic kinkmeme fills",
+    "series_index": 3.0
+  },
+  {
+    "id": 1932,
+    "series": "for pals",
+    "series_index": 2.0
+  },
+  {
+    "id": 1934,
+    "series": "Monsters.",
+    "series_index": 3.0
+  },
+  {
+    "id": 1936,
+    "series": "Dark Month 2014",
+    "series_index": 1.0
+  },
+  {
+    "id": 1937,
+    "series": "Dark Month 2014",
+    "series_index": 2.0
+  },
+  {
+    "id": 1938,
+    "series": "Dark Month 2014",
+    "series_index": 3.0
+  },
+  {
+    "id": 1944,
+    "series": "circling like vultures",
+    "series_index": 2.0
+  },
+  {
+    "id": 1945,
+    "series": "for pals",
+    "series_index": 1.0
+  },
+  {
+    "id": 1946,
+    "series": "To Love Mountains",
+    "series_index": 1.0
+  },
+  {
+    "id": 1948,
+    "series": "Marriage Principles",
+    "series_index": 2.0
+  },
+  {
+    "id": 1949,
+    "series": "To the Ends of the Earth",
+    "series_index": 7.0
+  },
+  {
+    "id": 1963,
+    "series": "Just Meng Yao Things",
+    "series_index": 2.0
+  },
+  {
+    "id": 1977,
+    "series": "Sun-Mars L5",
+    "series_index": 2.0
+  },
+  {
+    "id": 1978,
+    "series": "Sun-Mars L5",
+    "series_index": 1.0
+  },
+  {
+    "id": 1981,
+    "series": "the devil is the space between two men",
+    "series_index": 3.0
+  },
+  {
+    "id": 1986,
+    "series": "Guitar and Video Games",
+    "series_index": 10.0
+  },
+  {
+    "id": 1988,
+    "series": "In a meadow starred with flowers",
+    "series_index": 1.0
+  },
+  {
+    "id": 1991,
+    "series": "Just Meng Yao Things",
+    "series_index": 3.0
+  },
+  {
+    "id": 1996,
+    "series": "In a meadow starred with flowers",
+    "series_index": 2.0
+  },
+  {
+    "id": 1999,
+    "series": "looking back",
+    "series_index": 2.0
+  },
+  {
+    "id": 2002,
+    "series": "nhs's birthday 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 2003,
+    "series": "Jared's Vid Collection",
+    "series_index": 1.0
+  },
+  {
+    "id": 2012,
+    "series": "sweet as cherry wine",
+    "series_index": 1.0
+  },
+  {
+    "id": 2014,
+    "series": "for pals",
+    "series_index": 3.0
+  },
+  {
+    "id": 2017,
+    "series": "pathologic kinkmeme fills",
+    "series_index": 2.0
+  },
+  {
+    "id": 2022,
+    "series": "lovin', touchin', squeezin'",
+    "series_index": 1.0
+  },
+  {
+    "id": 2026,
+    "series": "Twelve Moons and a Fortnight Verse",
+    "series_index": 4.0
+  },
+  {
+    "id": 2027,
+    "series": "Rewritten",
+    "series_index": 1.0
+  },
+  {
+    "id": 2030,
+    "series": "We'd roll and fall in green",
+    "series_index": 1.0
+  },
+  {
+    "id": 2034,
+    "series": "To the Ends of the Earth",
+    "series_index": 10.0
+  },
+  {
+    "id": 2036,
+    "series": "2ha drabbles and ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 2038,
+    "series": "take me; take this",
+    "series_index": 1.0
+  },
+  {
+    "id": 2039,
+    "series": "looking back",
+    "series_index": 3.0
+  },
+  {
+    "id": 2042,
+    "series": "Requested Works",
+    "series_index": 2.0
+  },
+  {
+    "id": 2043,
+    "series": "Cataractae",
+    "series_index": 3.0
+  },
+  {
+    "id": 2046,
+    "series": "stand and face me, my love, and scatter the grace in your eyes",
+    "series_index": 2.0
+  },
+  {
+    "id": 2053,
+    "series": "Demarcation Line",
+    "series_index": 3.0
+  },
+  {
+    "id": 2063,
+    "series": "i'll be your girl",
+    "series_index": 1.0
+  },
+  {
+    "id": 2070,
+    "series": "Magical Nie clan fuck cave series",
+    "series_index": 1.0
+  },
+  {
+    "id": 2074,
+    "series": "How It Begins",
+    "series_index": 1.0
+  },
+  {
+    "id": 2075,
+    "series": "Jared's Vid Collection",
+    "series_index": 2.0
+  },
+  {
+    "id": 2080,
+    "series": "you can have what you want",
+    "series_index": 1.0
+  },
+  {
+    "id": 2083,
+    "series": "Lessons Learned",
+    "series_index": 1.0
+  },
+  {
+    "id": 2086,
+    "series": "Lessons Learned",
+    "series_index": 2.0
+  },
+  {
+    "id": 2087,
+    "series": "pathologic kinkmeme fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 2088,
+    "series": "swimming &amp; diving/college admissions scandal au",
+    "series_index": 1.0
+  },
+  {
+    "id": 2089,
+    "series": "you can have what you want",
+    "series_index": 2.0
+  },
+  {
+    "id": 2095,
+    "series": "\u8ab0\u8b02\u6cb3\u5ee3\u3001\u4e00\u8466\u676d\u4e4b | who says the river is wide (or, Lan Fangji)",
+    "series_index": 1.0
+  },
+  {
+    "id": 2096,
+    "series": "In a meadow starred with flowers",
+    "series_index": 3.0
+  },
+  {
+    "id": 2100,
+    "series": "a sensational team",
+    "series_index": 1.0
+  },
+  {
+    "id": 2104,
+    "series": "Just Meng Yao Things",
+    "series_index": 4.0
+  },
+  {
+    "id": 2109,
+    "series": "Walking Clothes Universe",
+    "series_index": 1.0
+  },
+  {
+    "id": 2110,
+    "series": "Walking Clothes Universe",
+    "series_index": 3.0
+  },
+  {
+    "id": 2113,
+    "series": "cloudy eyes",
+    "series_index": 1.0
+  },
+  {
+    "id": 2114,
+    "series": "We'd roll and fall in green",
+    "series_index": 2.0
+  },
+  {
+    "id": 2115,
+    "series": "Rewritten",
+    "series_index": 2.0
+  },
+  {
+    "id": 2118,
+    "series": "songs of love and devotion",
+    "series_index": 2.0
+  },
+  {
+    "id": 2120,
+    "series": "How It Begins",
+    "series_index": 5.0
+  },
+  {
+    "id": 2124,
+    "series": "binary stars beat together",
+    "series_index": 1.0
+  },
+  {
+    "id": 2125,
+    "series": "Lessons Learned",
+    "series_index": 3.0
+  },
+  {
+    "id": 2128,
+    "series": "sudden nature",
+    "series_index": 7.0
+  },
+  {
+    "id": 2131,
+    "series": "Art in Life",
+    "series_index": 1.0
+  },
+  {
+    "id": 2135,
+    "series": "histories",
+    "series_index": 2.0
+  },
+  {
+    "id": 2136,
+    "series": "the devil is the space between two men",
+    "series_index": 4.0
+  },
+  {
+    "id": 2137,
+    "series": "take me; take this",
+    "series_index": 2.0
+  },
+  {
+    "id": 2140,
+    "series": "qinghe triptych",
+    "series_index": 1.0
+  },
+  {
+    "id": 2141,
+    "series": "swimming &amp; diving/college admissions scandal au",
+    "series_index": 2.0
+  },
+  {
+    "id": 2149,
+    "series": "The Amazing Adventures Of Jiang Xiaolian And Family",
+    "series_index": 1.0
+  },
+  {
+    "id": 2156,
+    "series": "Devotion for Devotion",
+    "series_index": 1.0
+  },
+  {
+    "id": 2157,
+    "series": "Lessons Learned",
+    "series_index": 4.0
+  },
+  {
+    "id": 2159,
+    "series": "everything and everyone settled into place",
+    "series_index": 1.0
+  },
+  {
+    "id": 2160,
+    "series": "everything and everyone settled into place",
+    "series_index": 2.0
+  },
+  {
+    "id": 2166,
+    "series": "A Star to Steer By",
+    "series_index": 1.0
+  },
+  {
+    "id": 2167,
+    "series": "mdzs/cql ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 2170,
+    "series": "Acespec Chengning",
+    "series_index": 1.0
+  },
+  {
+    "id": 2172,
+    "series": "Professional Griefers",
+    "series_index": 1.0
+  },
+  {
+    "id": 2177,
+    "series": "Alchemical Processes",
+    "series_index": 3.0
+  },
+  {
+    "id": 2183,
+    "series": "pathologic kinkmeme fills",
+    "series_index": 4.0
+  },
+  {
+    "id": 2189,
+    "series": "genius of our minds",
+    "series_index": 1.0
+  },
+  {
+    "id": 2197,
+    "series": "Banned Together Bingo 2020 Fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 2199,
+    "series": "Just Meng Yao Things",
+    "series_index": 5.0
+  },
+  {
+    "id": 2201,
+    "series": "How It Begins",
+    "series_index": 2.0
+  },
+  {
+    "id": 2206,
+    "series": "Guitar and Video Games",
+    "series_index": 11.0
+  },
+  {
+    "id": 2211,
+    "series": "i'll be your girl",
+    "series_index": 2.0
+  },
+  {
+    "id": 2212,
+    "series": "histories",
+    "series_index": 3.0
+  },
+  {
+    "id": 2214,
+    "series": "empty | full",
+    "series_index": 1.0
+  },
+  {
+    "id": 2221,
+    "series": "In a meadow starred with flowers",
+    "series_index": 4.0
+  },
+  {
+    "id": 2223,
+    "series": "restrained",
+    "series_index": 1.0
+  },
+  {
+    "id": 2224,
+    "series": "Lessons Learned",
+    "series_index": 5.0
+  },
+  {
+    "id": 2232,
+    "series": "a sensational team",
+    "series_index": 2.0
+  },
+  {
+    "id": 2235,
+    "series": "swimming &amp; diving/college admissions scandal au",
+    "series_index": 3.0
+  },
+  {
+    "id": 2239,
+    "series": "Moon Frost Fest Bingo",
+    "series_index": 13.0
+  },
+  {
+    "id": 2243,
+    "series": "A Star to Steer By",
+    "series_index": 3.0
+  },
+  {
+    "id": 2244,
+    "series": "A Star to Steer By",
+    "series_index": 2.0
+  },
+  {
+    "id": 2245,
+    "series": "To love you is to know myself",
+    "series_index": 1.0
+  },
+  {
+    "id": 2248,
+    "series": "genius of our minds",
+    "series_index": 2.0
+  },
+  {
+    "id": 2252,
+    "series": "MDZS Kinkmeme 2020 Fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 2254,
+    "series": "the yunmeng accords",
+    "series_index": 1.0
+  },
+  {
+    "id": 2260,
+    "series": "the sentient sword spirit ones",
+    "series_index": 1.0
+  },
+  {
+    "id": 2268,
+    "series": "pathologic kinkmeme fills",
+    "series_index": 5.0
+  },
+  {
+    "id": 2269,
+    "series": "The Hangover: A pre-wedding Dramedy",
+    "series_index": 1.0
+  },
+  {
+    "id": 2271,
+    "series": "to remember names of plants",
+    "series_index": 2.0
+  },
+  {
+    "id": 2272,
+    "series": "mdzs kink meme prompts 2020",
+    "series_index": 2.0
+  },
+  {
+    "id": 2281,
+    "series": "Banned Together Bingo 2020 Fills",
+    "series_index": 2.0
+  },
+  {
+    "id": 2284,
+    "series": "An Island in Summer",
+    "series_index": 1.0
+  },
+  {
+    "id": 2285,
+    "series": "mdzs kink meme prompts 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 2291,
+    "series": "Thor Works",
+    "series_index": 2.0
+  },
+  {
+    "id": 2293,
+    "series": "put my mind at ease (pretty please)",
+    "series_index": 2.0
+  },
+  {
+    "id": 2299,
+    "series": "mdzs kink meme prompts 2020",
+    "series_index": 1.0
+  },
+  {
+    "id": 2304,
+    "series": "Painless Universe",
+    "series_index": 6.0
+  },
+  {
+    "id": 2307,
+    "series": "To the Ends of the Earth",
+    "series_index": 13.0
+  },
+  {
+    "id": 2316,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 2.0
+  },
+  {
+    "id": 2325,
+    "series": "Making Room",
+    "series_index": 1.0
+  },
+  {
+    "id": 2326,
+    "series": "\u8ab0\u8b02\u6cb3\u5ee3\u3001\u4e00\u8466\u676d\u4e4b | who says the river is wide (or, Lan Fangji)",
+    "series_index": 2.0
+  },
+  {
+    "id": 2328,
+    "series": "the sentient sword spirit ones",
+    "series_index": 3.0
+  },
+  {
+    "id": 2331,
+    "series": "qinghe triptych",
+    "series_index": 2.0
+  },
+  {
+    "id": 2333,
+    "series": "take me; take this",
+    "series_index": 3.0
+  },
+  {
+    "id": 2342,
+    "series": "The Hangover: A pre-wedding Dramedy",
+    "series_index": 2.0
+  },
+  {
+    "id": 2344,
+    "series": "mdzs kink meme prompts 2020",
+    "series_index": 4.0
+  },
+  {
+    "id": 2345,
+    "series": "Ways of Looking at a Blackbird",
+    "series_index": 1.0
+  },
+  {
+    "id": 2348,
+    "series": "O Brilliant Kids",
+    "series_index": 1.0
+  },
+  {
+    "id": 2350,
+    "series": "Tales of Work",
+    "series_index": 1.0
+  },
+  {
+    "id": 2351,
+    "series": "How It Begins",
+    "series_index": 3.0
+  },
+  {
+    "id": 2353,
+    "series": "sv fics (80% moshang)",
+    "series_index": 1.0
+  },
+  {
+    "id": 2355,
+    "series": "2ha drabbles and ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 2356,
+    "series": "Tumblr Fics",
+    "series_index": 4.0
+  },
+  {
+    "id": 2359,
+    "series": "a soft place to land",
+    "series_index": 1.0
+  },
+  {
+    "id": 2360,
+    "series": "The Hangover: A pre-wedding Dramedy",
+    "series_index": 3.0
+  },
+  {
+    "id": 2361,
+    "series": "the notes of an old mistake",
+    "series_index": 1.0
+  },
+  {
+    "id": 2363,
+    "series": "turn the page of the story",
+    "series_index": 1.0
+  },
+  {
+    "id": 2368,
+    "series": "What Spring Does With Cherry Trees",
+    "series_index": 1.0
+  },
+  {
+    "id": 2370,
+    "series": "arrangements collection",
+    "series_index": 1.0
+  },
+  {
+    "id": 2373,
+    "series": "1999",
+    "series_index": 1.0
+  },
+  {
+    "id": 2375,
+    "series": "sweet as cherry wine",
+    "series_index": 2.0
+  },
+  {
+    "id": 2376,
+    "series": "haemoglobin",
+    "series_index": 1.0
+  },
+  {
+    "id": 2378,
+    "series": "unexpected 'verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 2381,
+    "series": "The Song Lyric Killer",
+    "series_index": 1.0
+  },
+  {
+    "id": 2385,
+    "series": "layers of home",
+    "series_index": 2.0
+  },
+  {
+    "id": 2387,
+    "series": "MDZS &amp; CQL Kink meme fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 2396,
+    "series": "take me; take this",
+    "series_index": 4.0
+  },
+  {
+    "id": 2400,
+    "series": "Gametophyte",
+    "series_index": 1.0
+  },
+  {
+    "id": 2408,
+    "series": "Rewritten",
+    "series_index": 3.0
+  },
+  {
+    "id": 2410,
+    "series": "The Hangover: A pre-wedding Dramedy",
+    "series_index": 4.0
+  },
+  {
+    "id": 2411,
+    "series": "circling like vultures",
+    "series_index": 3.0
+  },
+  {
+    "id": 2412,
+    "series": "Seattle Xi'an Noodles-verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 2414,
+    "series": "arrangements collection",
+    "series_index": 2.0
+  },
+  {
+    "id": 2418,
+    "series": "Art in Life",
+    "series_index": 2.0
+  },
+  {
+    "id": 2427,
+    "series": "How It Begins",
+    "series_index": 4.0
+  },
+  {
+    "id": 2429,
+    "series": "Surrender Sweetly",
+    "series_index": 1.0
+  },
+  {
+    "id": 2430,
+    "series": "MDZS-Dissecting, Zealous Shimei",
+    "series_index": 3.0
+  },
+  {
+    "id": 2431,
+    "series": "arrangements collection",
+    "series_index": 3.0
+  },
+  {
+    "id": 2434,
+    "series": "Author's Favorites",
+    "series_index": 16.0
+  },
+  {
+    "id": 2436,
+    "series": "M\u00f3 D\u00e0o Z\u01d4 Sh\u012b | The Untamed Kink Meme 2020 Prompt Fills",
+    "series_index": 2.0
+  },
+  {
+    "id": 2440,
+    "series": "purple robes",
+    "series_index": 1.0
+  },
+  {
+    "id": 2444,
+    "series": "100 Follower Fic Requests",
+    "series_index": 1.0
+  },
+  {
+    "id": 2445,
+    "series": "pathologic kinkmeme fills",
+    "series_index": 6.0
+  },
+  {
+    "id": 2446,
+    "series": "Making Room",
+    "series_index": 2.0
+  },
+  {
+    "id": 2448,
+    "series": "Our Share of Night to Bear",
+    "series_index": 4.0
+  },
+  {
+    "id": 2449,
+    "series": "100 Follower Fic Requests",
+    "series_index": 2.0
+  },
+  {
+    "id": 2452,
+    "series": "Just Meng Yao Things",
+    "series_index": 6.0
+  },
+  {
+    "id": 2456,
+    "series": "The MDZS Bachelor Universe",
+    "series_index": 1.0
+  },
+  {
+    "id": 2457,
+    "series": "error: not found",
+    "series_index": 1.0
+  },
+  {
+    "id": 2458,
+    "series": "Modern Cultivator AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 2462,
+    "series": "Birdsongs",
+    "series_index": 2.0
+  },
+  {
+    "id": 2463,
+    "series": "the last gentian bride",
+    "series_index": 1.0
+  },
+  {
+    "id": 2465,
+    "series": "a soft place to land",
+    "series_index": 2.0
+  },
+  {
+    "id": 2466,
+    "series": "fierce corpse Jin Zixuan",
+    "series_index": 2.0
+  },
+  {
+    "id": 2469,
+    "series": "Birdsongs",
+    "series_index": 3.0
+  },
+  {
+    "id": 2472,
+    "series": "100 Follower Fic Requests",
+    "series_index": 3.0
+  },
+  {
+    "id": 2477,
+    "series": "Tales of Work",
+    "series_index": 2.0
+  },
+  {
+    "id": 2485,
+    "series": "Oops, We Filked It Again",
+    "series_index": 1.0
+  },
+  {
+    "id": 2486,
+    "series": "MDZS Reincarnation AU",
+    "series_index": 4.0
+  },
+  {
+    "id": 2488,
+    "series": "swimming &amp; diving/college admissions scandal au",
+    "series_index": 4.0
+  },
+  {
+    "id": 2494,
+    "series": "I could never give you peace",
+    "series_index": 1.0
+  },
+  {
+    "id": 2499,
+    "series": "Nielan Weekend 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 2500,
+    "series": "like the other boys do",
+    "series_index": 1.0
+  },
+  {
+    "id": 2502,
+    "series": "Oops, We Filked It Again",
+    "series_index": 2.0
+  },
+  {
+    "id": 2503,
+    "series": "long way home",
+    "series_index": 5.0
+  },
+  {
+    "id": 2507,
+    "series": "haemoglobin",
+    "series_index": 2.0
+  },
+  {
+    "id": 2511,
+    "series": "A Star to Steer By",
+    "series_index": 4.0
+  },
+  {
+    "id": 2516,
+    "series": "robes",
+    "series_index": 1.0
+  },
+  {
+    "id": 2524,
+    "series": "error: not found",
+    "series_index": 2.0
+  },
+  {
+    "id": 2527,
+    "series": "The Closest Three in the World",
+    "series_index": 1.0
+  },
+  {
+    "id": 2528,
+    "series": "Tales of Work",
+    "series_index": 3.0
+  },
+  {
+    "id": 2535,
+    "series": "Jared's Vid Collection",
+    "series_index": 3.0
+  },
+  {
+    "id": 2537,
+    "series": "mdzs kink meme prompts 2020",
+    "series_index": 5.0
+  },
+  {
+    "id": 2539,
+    "series": "tiny awoos",
+    "series_index": 3.0
+  },
+  {
+    "id": 2540,
+    "series": "Very Serious Request Fills",
+    "series_index": 4.0
+  },
+  {
+    "id": 2543,
+    "series": "mdzs twt fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 2544,
+    "series": "MDZS Kinkmeme 2020 Fills",
+    "series_index": 3.0
+  },
+  {
+    "id": 2553,
+    "series": "like the other boys do",
+    "series_index": 2.0
+  },
+  {
+    "id": 2555,
+    "series": "begins with a plie",
+    "series_index": 1.0
+  },
+  {
+    "id": 2562,
+    "series": "MDZS Kinkmeme Fills",
+    "series_index": 3.0
+  },
+  {
+    "id": 2566,
+    "series": "Commander Eliza Shepard",
+    "series_index": 2.0
+  },
+  {
+    "id": 2567,
+    "series": "You're the Light",
+    "series_index": 1.0
+  },
+  {
+    "id": 2587,
+    "series": "the last gentian bride",
+    "series_index": 2.0
+  },
+  {
+    "id": 2596,
+    "series": "our close and kindred ties",
+    "series_index": 1.0
+  },
+  {
+    "id": 2597,
+    "series": "Tales of Work",
+    "series_index": 4.0
+  },
+  {
+    "id": 2601,
+    "series": "To the Ends of the Earth",
+    "series_index": 14.0
+  },
+  {
+    "id": 2603,
+    "series": "Kat8's MDZS Kink Meme Fills",
+    "series_index": 6.0
+  },
+  {
+    "id": 2609,
+    "series": "King of Beasts",
+    "series_index": 1.0
+  },
+  {
+    "id": 2610,
+    "series": "100 Follower Fic Requests",
+    "series_index": 4.0
+  },
+  {
+    "id": 2614,
+    "series": "like the other boys do",
+    "series_index": 3.0
+  },
+  {
+    "id": 2616,
+    "series": "Explorations of Sub/Dom spaces",
+    "series_index": 1.0
+  },
+  {
+    "id": 2617,
+    "series": "our close and kindred ties",
+    "series_index": 2.0
+  },
+  {
+    "id": 2618,
+    "series": "How It Begins",
+    "series_index": 6.0
+  },
+  {
+    "id": 2621,
+    "series": "MDZS 2020 Kink Meme",
+    "series_index": 1.0
+  },
+  {
+    "id": 2623,
+    "series": "aizuchi",
+    "series_index": 2.0
+  },
+  {
+    "id": 2625,
+    "series": "in a veil of great surprises",
+    "series_index": 2.0
+  },
+  {
+    "id": 2632,
+    "series": "I could never give you peace",
+    "series_index": 3.0
+  },
+  {
+    "id": 2634,
+    "series": "The Sad and the Horny",
+    "series_index": 4.0
+  },
+  {
+    "id": 2642,
+    "series": "Ways of Looking at a Blackbird",
+    "series_index": 2.0
+  },
+  {
+    "id": 2651,
+    "series": "Pride Is Not The Word",
+    "series_index": 1.0
+  },
+  {
+    "id": 2658,
+    "series": "MDZS Tumblr Ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 2659,
+    "series": "Professional Griefers",
+    "series_index": 2.0
+  },
+  {
+    "id": 2663,
+    "series": "Guitar and Video Games",
+    "series_index": 12.0
+  },
+  {
+    "id": 2664,
+    "series": "studies of a complicit lan xichen",
+    "series_index": 1.0
+  },
+  {
+    "id": 2669,
+    "series": "A Star to Steer By",
+    "series_index": 5.0
+  },
+  {
+    "id": 2674,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 59.0
+  },
+  {
+    "id": 2675,
+    "series": "nightingale series",
+    "series_index": 1.0
+  },
+  {
+    "id": 2676,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 20.0
+  },
+  {
+    "id": 2679,
+    "series": "The Amazing Adventures Of Jiang Xiaolian And Family",
+    "series_index": 2.0
+  },
+  {
+    "id": 2682,
+    "series": "like the setting sun",
+    "series_index": 5.0
+  },
+  {
+    "id": 2693,
+    "series": "Surrender Sweetly",
+    "series_index": 2.0
+  },
+  {
+    "id": 2696,
+    "series": "studies of a complicit lan xichen",
+    "series_index": 2.0
+  },
+  {
+    "id": 2703,
+    "series": "qinghe triptych",
+    "series_index": 3.0
+  },
+  {
+    "id": 2705,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 2706,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 2707,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 3.0
+  },
+  {
+    "id": 2708,
+    "series": "Distress Call 'Verse",
+    "series_index": 3.0
+  },
+  {
+    "id": 2709,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 4.0
+  },
+  {
+    "id": 2710,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 5.0
+  },
+  {
+    "id": 2711,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 6.0
+  },
+  {
+    "id": 2712,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 7.0
+  },
+  {
+    "id": 2713,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 8.0
+  },
+  {
+    "id": 2714,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 9.0
+  },
+  {
+    "id": 2715,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 10.0
+  },
+  {
+    "id": 2716,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 11.0
+  },
+  {
+    "id": 2717,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 12.0
+  },
+  {
+    "id": 2718,
+    "series": "to one already dead",
+    "series_index": 1.0
+  },
+  {
+    "id": 2723,
+    "series": "take me; take this",
+    "series_index": 5.0
+  },
+  {
+    "id": 2725,
+    "series": "In the forests of the night.",
+    "series_index": 1.0
+  },
+  {
+    "id": 2726,
+    "series": "The Song Lyric Killer",
+    "series_index": 2.0
+  },
+  {
+    "id": 2727,
+    "series": "(fortunate orbit)",
+    "series_index": 1.0
+  },
+  {
+    "id": 2732,
+    "series": "(fortunate orbit)",
+    "series_index": 2.0
+  },
+  {
+    "id": 2735,
+    "series": "Synthesis",
+    "series_index": 1.0
+  },
+  {
+    "id": 2740,
+    "series": "Problematic Cloud Recesses Disciple Shenanigans",
+    "series_index": 1.0
+  },
+  {
+    "id": 2742,
+    "series": "turn the page of the story",
+    "series_index": 2.0
+  },
+  {
+    "id": 2758,
+    "series": "lmnop's MDZS/CQL Twitterfics (crossposted!)",
+    "series_index": 1.0
+  },
+  {
+    "id": 2759,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 62.0
+  },
+  {
+    "id": 2761,
+    "series": "In the forests of the night.",
+    "series_index": 2.0
+  },
+  {
+    "id": 2762,
+    "series": "Tales of Work",
+    "series_index": 5.0
+  },
+  {
+    "id": 2765,
+    "series": "lmnop's MDZS/CQL Twitterfics (crossposted!)",
+    "series_index": 2.0
+  },
+  {
+    "id": 2769,
+    "series": "ranwan mob au",
+    "series_index": 2.0
+  },
+  {
+    "id": 2772,
+    "series": "I could never give you peace",
+    "series_index": 2.0
+  },
+  {
+    "id": 2773,
+    "series": "To love you is to know myself",
+    "series_index": 2.0
+  },
+  {
+    "id": 2778,
+    "series": "You're the Light",
+    "series_index": 2.0
+  },
+  {
+    "id": 2785,
+    "series": "pathologic kinkmeme fills",
+    "series_index": 7.0
+  },
+  {
+    "id": 2787,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 7.0
+  },
+  {
+    "id": 2791,
+    "series": "Making Room",
+    "series_index": 3.0
+  },
+  {
+    "id": 2794,
+    "series": "take me; take this",
+    "series_index": 6.0
+  },
+  {
+    "id": 2799,
+    "series": "Remember This Cold",
+    "series_index": 28.0
+  },
+  {
+    "id": 2801,
+    "series": "in a veil of great surprises",
+    "series_index": 1.0
+  },
+  {
+    "id": 2802,
+    "series": "empty | full",
+    "series_index": 2.0
+  },
+  {
+    "id": 2804,
+    "series": "Every You Every Me",
+    "series_index": 1.0
+  },
+  {
+    "id": 2809,
+    "series": "to mend our broken souls",
+    "series_index": 1.0
+  },
+  {
+    "id": 2817,
+    "series": "Ingredients of Your Gift",
+    "series_index": 1.0
+  },
+  {
+    "id": 2818,
+    "series": "the last gentian bride",
+    "series_index": 3.0
+  },
+  {
+    "id": 2819,
+    "series": "1999",
+    "series_index": 2.0
+  },
+  {
+    "id": 2821,
+    "series": "Ingredients of Your Gift",
+    "series_index": 2.0
+  },
+  {
+    "id": 2823,
+    "series": "take me; take this",
+    "series_index": 7.0
+  },
+  {
+    "id": 2829,
+    "series": "A Little Less Afraid",
+    "series_index": 1.0
+  },
+  {
+    "id": 2835,
+    "series": "Problematic Cloud Recesses Disciple Shenanigans",
+    "series_index": 2.0
+  },
+  {
+    "id": 2837,
+    "series": "Guitar and Video Games",
+    "series_index": 13.0
+  },
+  {
+    "id": 2839,
+    "series": "domestic demonic pest control",
+    "series_index": 1.0
+  },
+  {
+    "id": 2840,
+    "series": "our close and kindred ties",
+    "series_index": 3.0
+  },
+  {
+    "id": 2850,
+    "series": "Explorations of Sub/Dom spaces",
+    "series_index": 2.0
+  },
+  {
+    "id": 2852,
+    "series": "Zines and Events",
+    "series_index": 7.0
+  },
+  {
+    "id": 2856,
+    "series": "Every You Every Me",
+    "series_index": 2.0
+  },
+  {
+    "id": 2857,
+    "series": "Author's Favorites",
+    "series_index": 7.0
+  },
+  {
+    "id": 2859,
+    "series": "Jared's Vid Collection",
+    "series_index": 4.0
+  },
+  {
+    "id": 2860,
+    "series": "collected scenes",
+    "series_index": 1.0
+  },
+  {
+    "id": 2868,
+    "series": "a soft place to land",
+    "series_index": 3.0
+  },
+  {
+    "id": 2871,
+    "series": "the notes of an old mistake",
+    "series_index": 2.0
+  },
+  {
+    "id": 2877,
+    "series": "metro detroit cinematic smutiverse",
+    "series_index": 1.0
+  },
+  {
+    "id": 2878,
+    "series": "A Star to Steer By",
+    "series_index": 6.0
+  },
+  {
+    "id": 2882,
+    "series": "sweet grasses",
+    "series_index": 1.0
+  },
+  {
+    "id": 2886,
+    "series": "Butterfly Dreams",
+    "series_index": 1.0
+  },
+  {
+    "id": 2887,
+    "series": "Synthesis",
+    "series_index": 2.0
+  },
+  {
+    "id": 2891,
+    "series": "Ingredients of Your Gift",
+    "series_index": 3.0
+  },
+  {
+    "id": 2895,
+    "series": "Butterfly Dreams",
+    "series_index": 2.0
+  },
+  {
+    "id": 2899,
+    "series": "A Star to Steer By",
+    "series_index": 7.0
+  },
+  {
+    "id": 2903,
+    "series": "the dead horse",
+    "series_index": 2.0
+  },
+  {
+    "id": 2911,
+    "series": "reclaim the rising",
+    "series_index": 6.0
+  },
+  {
+    "id": 2920,
+    "series": "take me; take this",
+    "series_index": 8.0
+  },
+  {
+    "id": 2921,
+    "series": "domestic demonic pest control",
+    "series_index": 2.0
+  },
+  {
+    "id": 2925,
+    "series": "lovesong for between-places",
+    "series_index": 1.0
+  },
+  {
+    "id": 2930,
+    "series": "mdzs daemon au",
+    "series_index": 1.0
+  },
+  {
+    "id": 2931,
+    "series": "for pals",
+    "series_index": 4.0
+  },
+  {
+    "id": 2934,
+    "series": "Mother, Mother, Mother",
+    "series_index": 1.0
+  },
+  {
+    "id": 2937,
+    "series": "Art in Life",
+    "series_index": 3.0
+  },
+  {
+    "id": 2944,
+    "series": "Seattle Xi'an Noodles-verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 2947,
+    "series": "Westie's MDZS/CQL Tumblr Ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 2948,
+    "series": "Westie's MDZS/CQL Tumblr Ficlets",
+    "series_index": 3.0
+  },
+  {
+    "id": 2957,
+    "series": "JTWYA-verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 2958,
+    "series": "Every You Every Me",
+    "series_index": 3.0
+  },
+  {
+    "id": 2959,
+    "series": "sweet grasses",
+    "series_index": 2.0
+  },
+  {
+    "id": 2961,
+    "series": "Birdsongs",
+    "series_index": 8.0
+  },
+  {
+    "id": 2962,
+    "series": "somewhere i have never traveled,gladly beyond",
+    "series_index": 1.0
+  },
+  {
+    "id": 2964,
+    "series": "tattered, tethered",
+    "series_index": 1.0
+  },
+  {
+    "id": 2967,
+    "series": "to mend our broken souls",
+    "series_index": 2.0
+  },
+  {
+    "id": 2981,
+    "series": "sv fics (80% moshang)",
+    "series_index": 2.0
+  },
+  {
+    "id": 2986,
+    "series": "somewhere i have never traveled,gladly beyond",
+    "series_index": 3.0
+  },
+  {
+    "id": 2991,
+    "series": "sv fics (80% moshang)",
+    "series_index": 3.0
+  },
+  {
+    "id": 2996,
+    "series": "cursed kinks",
+    "series_index": 1.0
+  },
+  {
+    "id": 2999,
+    "series": "silt, or scurvy",
+    "series_index": 1.0
+  },
+  {
+    "id": 3000,
+    "series": "Moshang Week 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 3001,
+    "series": "to dwell inside a body",
+    "series_index": 1.0
+  },
+  {
+    "id": 3012,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 33.0
+  },
+  {
+    "id": 3013,
+    "series": "mdzs kink meme prompts 2020",
+    "series_index": 7.0
+  },
+  {
+    "id": 3014,
+    "series": "Untamed Kink Meme Fills",
+    "series_index": 3.0
+  },
+  {
+    "id": 3017,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 3028,
+    "series": "you're like candy, you go down so easily",
+    "series_index": 2.0
+  },
+  {
+    "id": 3032,
+    "series": "Mother, Mother, Mother",
+    "series_index": 2.0
+  },
+  {
+    "id": 3036,
+    "series": "frayed",
+    "series_index": 1.0
+  },
+  {
+    "id": 3037,
+    "series": "meet me back by the sea",
+    "series_index": 1.0
+  },
+  {
+    "id": 3039,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 1.0
+  },
+  {
+    "id": 3042,
+    "series": "set your old heart free",
+    "series_index": 1.0
+  },
+  {
+    "id": 3043,
+    "series": "a sensational team",
+    "series_index": 3.0
+  },
+  {
+    "id": 3047,
+    "series": "Lesbian-Centric Semi-Non-Human Throuple",
+    "series_index": 1.0
+  },
+  {
+    "id": 3048,
+    "series": "like the other boys do",
+    "series_index": 4.0
+  },
+  {
+    "id": 3049,
+    "series": "sv fics (80% moshang)",
+    "series_index": 4.0
+  },
+  {
+    "id": 3050,
+    "series": "somewhere i have never traveled,gladly beyond",
+    "series_index": 1.0
+  },
+  {
+    "id": 3054,
+    "series": "proxybird's 2020 kinktober fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 3060,
+    "series": "MDZS Kinktober 2020",
+    "series_index": 4.0
+  },
+  {
+    "id": 3061,
+    "series": "Niecest Week 2020 ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 3066,
+    "series": "Niecest Week 2020 ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 3067,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 2.0
+  },
+  {
+    "id": 3071,
+    "series": "Niecest Week 2020 ficlets",
+    "series_index": 3.0
+  },
+  {
+    "id": 3073,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 3.0
+  },
+  {
+    "id": 3076,
+    "series": "for pals",
+    "series_index": 5.0
+  },
+  {
+    "id": 3077,
+    "series": "studies of a complicit lan xichen",
+    "series_index": 3.0
+  },
+  {
+    "id": 3081,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 4.0
+  },
+  {
+    "id": 3085,
+    "series": "the notes of an old mistake",
+    "series_index": 3.0
+  },
+  {
+    "id": 3086,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 5.0
+  },
+  {
+    "id": 3087,
+    "series": "The rest of our lives",
+    "series_index": 1.0
+  },
+  {
+    "id": 3088,
+    "series": "the places Nobody knows",
+    "series_index": 3.0
+  },
+  {
+    "id": 3091,
+    "series": "Niecest Week 2020 ficlets",
+    "series_index": 4.0
+  },
+  {
+    "id": 3092,
+    "series": "Niecest Week 2020 ficlets",
+    "series_index": 5.0
+  },
+  {
+    "id": 3095,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 6.0
+  },
+  {
+    "id": 3101,
+    "series": "Bod(ies)",
+    "series_index": 1.0
+  },
+  {
+    "id": 3102,
+    "series": "Kinkmeme Fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 3104,
+    "series": "post-canon lan xichen has a miserable time",
+    "series_index": 1.0
+  },
+  {
+    "id": 3105,
+    "series": "lovesong for between-places",
+    "series_index": 2.0
+  },
+  {
+    "id": 3107,
+    "series": "our close and kindred ties",
+    "series_index": 5.0
+  },
+  {
+    "id": 3113,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 6.0
+  },
+  {
+    "id": 3114,
+    "series": "like the other boys do",
+    "series_index": 5.0
+  },
+  {
+    "id": 3117,
+    "series": "tattered, tethered",
+    "series_index": 2.0
+  },
+  {
+    "id": 3118,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 7.0
+  },
+  {
+    "id": 3121,
+    "series": "binary stars beat together",
+    "series_index": 2.0
+  },
+  {
+    "id": 3122,
+    "series": "to dwell inside a body",
+    "series_index": 2.0
+  },
+  {
+    "id": 3123,
+    "series": "lmnop's MDZS/CQL Twitterfics (crossposted!)",
+    "series_index": 3.0
+  },
+  {
+    "id": 3126,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 8.0
+  },
+  {
+    "id": 3134,
+    "series": "A Thesis on Possession",
+    "series_index": 1.0
+  },
+  {
+    "id": 3138,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 9.0
+  },
+  {
+    "id": 3144,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 10.0
+  },
+  {
+    "id": 3148,
+    "series": "author's mdzs faves",
+    "series_index": 2.0
+  },
+  {
+    "id": 3149,
+    "series": "Surrender Sweetly",
+    "series_index": 3.0
+  },
+  {
+    "id": 3152,
+    "series": "Come in from the cold (let's warm up together)",
+    "series_index": 1.0
+  },
+  {
+    "id": 3154,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 11.0
+  },
+  {
+    "id": 3157,
+    "series": "1999",
+    "series_index": 3.0
+  },
+  {
+    "id": 3159,
+    "series": "mdzs prompt fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 3162,
+    "series": "Come in from the cold (let's warm up together)",
+    "series_index": 2.0
+  },
+  {
+    "id": 3166,
+    "series": "Oops, We Filked It Again",
+    "series_index": 6.0
+  },
+  {
+    "id": 3167,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 61.0
+  },
+  {
+    "id": 3168,
+    "series": "Baby, you could fuck up my whole life",
+    "series_index": 1.0
+  },
+  {
+    "id": 3170,
+    "series": "\u8f69\u626c\u6492\u624b (on the edge of this cliff, and i'm letting go)",
+    "series_index": 1.0
+  },
+  {
+    "id": 3171,
+    "series": "our close and kindred ties",
+    "series_index": 4.0
+  },
+  {
+    "id": 3172,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 12.0
+  },
+  {
+    "id": 3173,
+    "series": "Come in from the cold (let's warm up together)",
+    "series_index": 3.0
+  },
+  {
+    "id": 3177,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 13.0
+  },
+  {
+    "id": 3180,
+    "series": "The Rouge King",
+    "series_index": 1.0
+  },
+  {
+    "id": 3181,
+    "series": "Come in from the cold (let's warm up together)",
+    "series_index": 4.0
+  },
+  {
+    "id": 3182,
+    "series": "A Star to Steer By",
+    "series_index": 8.0
+  },
+  {
+    "id": 3183,
+    "series": "Whumptober 2020: Yi City Edition",
+    "series_index": 14.0
+  },
+  {
+    "id": 3190,
+    "series": "Come in from the cold (let's warm up together)",
+    "series_index": 5.0
+  },
+  {
+    "id": 3193,
+    "series": "reclaim the rising",
+    "series_index": 7.0
+  },
+  {
+    "id": 3194,
+    "series": "the notes of an old mistake",
+    "series_index": 4.0
+  },
+  {
+    "id": 3196,
+    "series": "Come in from the cold (let's warm up together)",
+    "series_index": 6.0
+  },
+  {
+    "id": 3198,
+    "series": "lovesong for between-places",
+    "series_index": 3.0
+  },
+  {
+    "id": 3199,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 63.0
+  },
+  {
+    "id": 3202,
+    "series": "orchidverse",
+    "series_index": 2.0
+  },
+  {
+    "id": 3204,
+    "series": "A Little Less Afraid",
+    "series_index": 2.0
+  },
+  {
+    "id": 3205,
+    "series": "the long weekend home",
+    "series_index": 1.0
+  },
+  {
+    "id": 3211,
+    "series": "post-canon lan xichen has a miserable time",
+    "series_index": 2.0
+  },
+  {
+    "id": 3212,
+    "series": "the untamed requests + twitfics (gremlin babie hurts you kindly)",
+    "series_index": 1.0
+  },
+  {
+    "id": 3213,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 13.0
+  },
+  {
+    "id": 3214,
+    "series": "the untamed requests + twitfics (gremlin babie hurts you kindly)",
+    "series_index": 2.0
+  },
+  {
+    "id": 3215,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 14.0
+  },
+  {
+    "id": 3216,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 15.0
+  },
+  {
+    "id": 3217,
+    "series": "the untamed requests + twitfics (gremlin babie hurts you kindly)",
+    "series_index": 3.0
+  },
+  {
+    "id": 3219,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 16.0
+  },
+  {
+    "id": 3220,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 17.0
+  },
+  {
+    "id": 3221,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 18.0
+  },
+  {
+    "id": 3222,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 19.0
+  },
+  {
+    "id": 3223,
+    "series": "teen wolf tumblr drabbles and ficlets",
+    "series_index": 20.0
+  },
+  {
+    "id": 3224,
+    "series": "the untamed requests + twitfics (gremlin babie hurts you kindly)",
+    "series_index": 4.0
+  },
+  {
+    "id": 3225,
+    "series": "the untamed requests + twitfics (gremlin babie hurts you kindly)",
+    "series_index": 5.0
+  },
+  {
+    "id": 3226,
+    "series": "the untamed requests + twitfics (gremlin babie hurts you kindly)",
+    "series_index": 6.0
+  },
+  {
+    "id": 3229,
+    "series": "still breathing",
+    "series_index": 1.0
+  },
+  {
+    "id": 3230,
+    "series": "reclaim the rising",
+    "series_index": 8.0
+  },
+  {
+    "id": 3232,
+    "series": "the long weekend home",
+    "series_index": 2.0
+  },
+  {
+    "id": 3243,
+    "series": "A Thesis on Possession",
+    "series_index": 2.0
+  },
+  {
+    "id": 3246,
+    "series": "the untamed requests + twitfics (gremlin babie hurts you kindly)",
+    "series_index": 7.0
+  },
+  {
+    "id": 3247,
+    "series": "mdzs &amp; etc",
+    "series_index": 1.0
+  },
+  {
+    "id": 3253,
+    "series": "What we do in the Nightless City",
+    "series_index": 1.0
+  },
+  {
+    "id": 3259,
+    "series": "modern sandbox",
+    "series_index": 1.0
+  },
+  {
+    "id": 3267,
+    "series": "Zines and Events",
+    "series_index": 8.0
+  },
+  {
+    "id": 3273,
+    "series": "care package",
+    "series_index": 1.0
+  },
+  {
+    "id": 3282,
+    "series": "a comet pulled from orbit",
+    "series_index": 1.0
+  },
+  {
+    "id": 3283,
+    "series": "This is how we mend our shattered hearts",
+    "series_index": 4.0
+  },
+  {
+    "id": 3288,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 65.0
+  },
+  {
+    "id": 3290,
+    "series": "tattered, tethered",
+    "series_index": 3.0
+  },
+  {
+    "id": 3292,
+    "series": "Seattle Xi'an Noodles-verse",
+    "series_index": 3.0
+  },
+  {
+    "id": 3299,
+    "series": "CHAOS FARM",
+    "series_index": 1.0
+  },
+  {
+    "id": 3301,
+    "series": "frayed",
+    "series_index": 2.0
+  },
+  {
+    "id": 3302,
+    "series": "Professional Griefers",
+    "series_index": 3.0
+  },
+  {
+    "id": 3304,
+    "series": "Chengyi Week 2020",
+    "series_index": 1.0
+  },
+  {
+    "id": 3314,
+    "series": "Distant Shores and Voices",
+    "series_index": 12.0
+  },
+  {
+    "id": 3315,
+    "series": "Chengyi Week 2020",
+    "series_index": 2.0
+  },
+  {
+    "id": 3319,
+    "series": "Ways of Looking at a Blackbird",
+    "series_index": 3.0
+  },
+  {
+    "id": 3322,
+    "series": "Baby, you could fuck up my whole life",
+    "series_index": 2.0
+  },
+  {
+    "id": 3323,
+    "series": "Chengyi Week 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 3324,
+    "series": "Chengyi Week 2020",
+    "series_index": 4.0
+  },
+  {
+    "id": 3328,
+    "series": "Chengyi Week 2020",
+    "series_index": 5.0
+  },
+  {
+    "id": 3336,
+    "series": "Chengyi Week 2020",
+    "series_index": 6.0
+  },
+  {
+    "id": 3338,
+    "series": "sv fics (80% moshang)",
+    "series_index": 5.0
+  },
+  {
+    "id": 3347,
+    "series": "Chengyi Week 2020",
+    "series_index": 7.0
+  },
+  {
+    "id": 3351,
+    "series": "robes",
+    "series_index": 2.0
+  },
+  {
+    "id": 3353,
+    "series": "mdzs &amp; etc",
+    "series_index": 2.0
+  },
+  {
+    "id": 3361,
+    "series": "reclaim the rising",
+    "series_index": 4.0
+  },
+  {
+    "id": 3362,
+    "series": "BDSM AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 3364,
+    "series": "like the other boys do",
+    "series_index": 6.0
+  },
+  {
+    "id": 3365,
+    "series": "care package",
+    "series_index": 2.0
+  },
+  {
+    "id": 3367,
+    "series": "BDSM AU",
+    "series_index": 4.0
+  },
+  {
+    "id": 3372,
+    "series": "to one already dead",
+    "series_index": 2.0
+  },
+  {
+    "id": 3375,
+    "series": "BDSM AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 3384,
+    "series": "the long weekend home",
+    "series_index": 3.0
+  },
+  {
+    "id": 3400,
+    "series": "care package",
+    "series_index": 3.0
+  },
+  {
+    "id": 3401,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 1.0
+  },
+  {
+    "id": 3402,
+    "series": "CHAOS FARM",
+    "series_index": 2.0
+  },
+  {
+    "id": 3404,
+    "series": "The Rouge King",
+    "series_index": 2.0
+  },
+  {
+    "id": 3411,
+    "series": "On Reflections",
+    "series_index": 1.0
+  },
+  {
+    "id": 3412,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 2.0
+  },
+  {
+    "id": 3416,
+    "series": "for pals",
+    "series_index": 6.0
+  },
+  {
+    "id": 3423,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 2.0
+  },
+  {
+    "id": 3425,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 3.0
+  },
+  {
+    "id": 3426,
+    "series": "no one calls you honey when you're sitting on a throne",
+    "series_index": 1.0
+  },
+  {
+    "id": 3427,
+    "series": "MDZS/CQL Tumblr Fics",
+    "series_index": 13.0
+  },
+  {
+    "id": 3433,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 3.0
+  },
+  {
+    "id": 3434,
+    "series": "The Other End of the Sky",
+    "series_index": 1.0
+  },
+  {
+    "id": 3435,
+    "series": "Twitter Fics",
+    "series_index": 1.0
+  },
+  {
+    "id": 3438,
+    "series": "Seattle Xi'an Noodles-verse",
+    "series_index": 4.0
+  },
+  {
+    "id": 3440,
+    "series": "MXTX Gen Week 2020",
+    "series_index": 3.0
+  },
+  {
+    "id": 3441,
+    "series": "robes",
+    "series_index": 3.0
+  },
+  {
+    "id": 3443,
+    "series": "care package",
+    "series_index": 4.0
+  },
+  {
+    "id": 3445,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 4.0
+  },
+  {
+    "id": 3448,
+    "series": "held my burning heart",
+    "series_index": 1.0
+  },
+  {
+    "id": 3449,
+    "series": "MXTX Gen Week 2020",
+    "series_index": 4.0
+  },
+  {
+    "id": 3450,
+    "series": "held my burning heart",
+    "series_index": 2.0
+  },
+  {
+    "id": 3452,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 4.0
+  },
+  {
+    "id": 3453,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 5.0
+  },
+  {
+    "id": 3458,
+    "series": "MXTX Gen Week 2020",
+    "series_index": 6.0
+  },
+  {
+    "id": 3459,
+    "series": "tattered, tethered",
+    "series_index": 4.0
+  },
+  {
+    "id": 3461,
+    "series": "take me; take this",
+    "series_index": 9.0
+  },
+  {
+    "id": 3463,
+    "series": "like the other boys do",
+    "series_index": 7.0
+  },
+  {
+    "id": 3464,
+    "series": "metro detroit cinematic smutiverse",
+    "series_index": 2.0
+  },
+  {
+    "id": 3466,
+    "series": "domestic demonic pest control",
+    "series_index": 3.0
+  },
+  {
+    "id": 3469,
+    "series": "no one calls you honey when you're sitting on a throne",
+    "series_index": 2.0
+  },
+  {
+    "id": 3470,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 5.0
+  },
+  {
+    "id": 3471,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 6.0
+  },
+  {
+    "id": 3473,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 7.0
+  },
+  {
+    "id": 3475,
+    "series": "JTWYA-verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 3477,
+    "series": "a comet pulled from orbit",
+    "series_index": 2.0
+  },
+  {
+    "id": 3478,
+    "series": "Fuck Around and Find Out",
+    "series_index": 1.0
+  },
+  {
+    "id": 3486,
+    "series": "See all this and more for just ten dollars a month!",
+    "series_index": 2.0
+  },
+  {
+    "id": 3487,
+    "series": "By Degrees",
+    "series_index": 2.0
+  },
+  {
+    "id": 3488,
+    "series": "MDZS Drabbles",
+    "series_index": 3.0
+  },
+  {
+    "id": 3494,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 7.0
+  },
+  {
+    "id": 3496,
+    "series": "vampire AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 3498,
+    "series": "BDSM AU",
+    "series_index": 2.0
+  },
+  {
+    "id": 3500,
+    "series": "A Thesis on Possession",
+    "series_index": 3.0
+  },
+  {
+    "id": 3503,
+    "series": "reclaim the rising",
+    "series_index": 2.0
+  },
+  {
+    "id": 3509,
+    "series": "restrained",
+    "series_index": 2.0
+  },
+  {
+    "id": 3511,
+    "series": "Ingredients of Your Gift",
+    "series_index": 4.0
+  },
+  {
+    "id": 3512,
+    "series": "vampire AU",
+    "series_index": 2.0
+  },
+  {
+    "id": 3514,
+    "series": "mdzs &amp; etc",
+    "series_index": 3.0
+  },
+  {
+    "id": 3515,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 8.0
+  },
+  {
+    "id": 3521,
+    "series": "Ill Gotten Son",
+    "series_index": 1.0
+  },
+  {
+    "id": 3523,
+    "series": "Ill Gotten Son",
+    "series_index": 2.0
+  },
+  {
+    "id": 3524,
+    "series": "Ill Gotten Son",
+    "series_index": 3.0
+  },
+  {
+    "id": 3527,
+    "series": "Ill Gotten Son",
+    "series_index": 4.0
+  },
+  {
+    "id": 3529,
+    "series": "Ill Gotten Son",
+    "series_index": 5.0
+  },
+  {
+    "id": 3533,
+    "series": "Tales of Work",
+    "series_index": 6.0
+  },
+  {
+    "id": 3535,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 35.0
+  },
+  {
+    "id": 3536,
+    "series": "purple robes",
+    "series_index": 2.0
+  },
+  {
+    "id": 3537,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 67.0
+  },
+  {
+    "id": 3538,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 57.0
+  },
+  {
+    "id": 3540,
+    "series": "Twitter Fics",
+    "series_index": 1.0
+  },
+  {
+    "id": 3547,
+    "series": "Meng Yao vs. the Board of the Homeowner's Association",
+    "series_index": 9.0
+  },
+  {
+    "id": 3548,
+    "series": "Author's Favorites",
+    "series_index": 3.0
+  },
+  {
+    "id": 3550,
+    "series": "the long weekend home",
+    "series_index": 4.0
+  },
+  {
+    "id": 3551,
+    "series": "It's Shadowhawk, who dis? (Hawkshadow remix)",
+    "series_index": 5.0
+  },
+  {
+    "id": 3552,
+    "series": "Shattered",
+    "series_index": 1.0
+  },
+  {
+    "id": 3554,
+    "series": "Everyone Loves Shang Qinghua (My Canon Now)",
+    "series_index": 15.0
+  },
+  {
+    "id": 3555,
+    "series": "It's Shadowhawk, who dis? (Hawkshadow remix)",
+    "series_index": 2.0
+  },
+  {
+    "id": 3556,
+    "series": "It's Shadowhawk, who dis? (Hawkshadow remix)",
+    "series_index": 3.0
+  },
+  {
+    "id": 3559,
+    "series": "histories",
+    "series_index": 4.0
+  },
+  {
+    "id": 3583,
+    "series": "truth or dare",
+    "series_index": 1.0
+  },
+  {
+    "id": 3611,
+    "series": "time-sensitive.",
+    "series_index": 1.0
+  },
+  {
+    "id": 3614,
+    "series": "Shattered",
+    "series_index": 2.0
+  },
+  {
+    "id": 3635,
+    "series": "three's a crowd, four's a party",
+    "series_index": 1.0
+  },
+  {
+    "id": 3638,
+    "series": "it's worth it every time",
+    "series_index": 1.0
+  },
+  {
+    "id": 3655,
+    "series": "Working Title: Everyone Lives (With Knives)",
+    "series_index": 1.0
+  },
+  {
+    "id": 3658,
+    "series": "Twitter Fics",
+    "series_index": 2.0
+  },
+  {
+    "id": 3660,
+    "series": "Jared's Vid Collection",
+    "series_index": 5.0
+  },
+  {
+    "id": 3663,
+    "series": "It's Shadowhawk, who dis? (Hawkshadow remix)",
+    "series_index": 1.0
+  },
+  {
+    "id": 3664,
+    "series": "Twitter Fics",
+    "series_index": 3.0
+  },
+  {
+    "id": 3665,
+    "series": "It's Shadowhawk, who dis? (Hawkshadow remix)",
+    "series_index": 4.0
+  },
+  {
+    "id": 3678,
+    "series": "that summer feelin'",
+    "series_index": 2.0
+  },
+  {
+    "id": 3684,
+    "series": "frayed",
+    "series_index": 3.0
+  },
+  {
+    "id": 3685,
+    "series": "Remember This Cold",
+    "series_index": 18.0
+  },
+  {
+    "id": 3686,
+    "series": "blood in the water",
+    "series_index": 1.0
+  },
+  {
+    "id": 3691,
+    "series": "A Star to Steer By",
+    "series_index": 9.0
+  },
+  {
+    "id": 3692,
+    "series": "To be a pair of butterflies",
+    "series_index": 1.0
+  },
+  {
+    "id": 3693,
+    "series": "time-sensitive.",
+    "series_index": 2.0
+  },
+  {
+    "id": 3695,
+    "series": "it's worth it every time",
+    "series_index": 2.0
+  },
+  {
+    "id": 3707,
+    "series": "held my burning heart",
+    "series_index": 3.0
+  },
+  {
+    "id": 3716,
+    "series": "Cry a river, call it rain",
+    "series_index": 1.0
+  },
+  {
+    "id": 3719,
+    "series": "Stupid Love",
+    "series_index": 1.0
+  },
+  {
+    "id": 3723,
+    "series": "Make the glass shake",
+    "series_index": 1.0
+  },
+  {
+    "id": 3733,
+    "series": "Make the glass shake",
+    "series_index": 2.0
+  },
+  {
+    "id": 3734,
+    "series": "constellations",
+    "series_index": 1.0
+  },
+  {
+    "id": 3747,
+    "series": "Wei Wuxian Makes a Wish",
+    "series_index": 1.0
+  },
+  {
+    "id": 3750,
+    "series": "More Than You Know",
+    "series_index": 1.0
+  },
+  {
+    "id": 3759,
+    "series": "Fix Huaisang's Life",
+    "series_index": 1.0
+  },
+  {
+    "id": 3760,
+    "series": "BDSM AU",
+    "series_index": 3.0
+  },
+  {
+    "id": 3766,
+    "series": "after",
+    "series_index": 2.0
+  },
+  {
+    "id": 3770,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 3.0
+  },
+  {
+    "id": 3771,
+    "series": "compression molding (boxing a-yao)",
+    "series_index": 1.0
+  },
+  {
+    "id": 3772,
+    "series": "compression molding (boxing a-yao)",
+    "series_index": 2.0
+  },
+  {
+    "id": 3774,
+    "series": "Make the glass shake",
+    "series_index": 3.0
+  },
+  {
+    "id": 3775,
+    "series": "Oops, We Filked It Again",
+    "series_index": 13.0
+  },
+  {
+    "id": 3783,
+    "series": "Oops, We Filked It Again",
+    "series_index": 14.0
+  },
+  {
+    "id": 3785,
+    "series": "untitled",
+    "series_index": 8.0
+  },
+  {
+    "id": 3792,
+    "series": "JTWYA-verse",
+    "series_index": 3.0
+  },
+  {
+    "id": 3800,
+    "series": "frayed",
+    "series_index": 4.0
+  },
+  {
+    "id": 3802,
+    "series": "Condensationverse",
+    "series_index": 1.0
+  },
+  {
+    "id": 3803,
+    "series": "Recovery",
+    "series_index": 1.0
+  },
+  {
+    "id": 3806,
+    "series": "held my burning heart",
+    "series_index": 4.0
+  },
+  {
+    "id": 3817,
+    "series": "Bod(ies)",
+    "series_index": 2.0
+  },
+  {
+    "id": 3824,
+    "series": "begins with a plie",
+    "series_index": 2.0
+  },
+  {
+    "id": 3827,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 6.0
+  },
+  {
+    "id": 3829,
+    "series": "baby twin jades bday fics",
+    "series_index": 2.0
+  },
+  {
+    "id": 3831,
+    "series": "everyone lives; everyone fucks",
+    "series_index": 1.0
+  },
+  {
+    "id": 3842,
+    "series": "if living can be this",
+    "series_index": 1.0
+  },
+  {
+    "id": 3843,
+    "series": "Author's Favorites",
+    "series_index": 4.0
+  },
+  {
+    "id": 3848,
+    "series": "time, curious time",
+    "series_index": 1.0
+  },
+  {
+    "id": 3851,
+    "series": "ranwan kinktober 2020",
+    "series_index": 2.0
+  },
+  {
+    "id": 3854,
+    "series": "Fuck Around and Find Out",
+    "series_index": 2.0
+  },
+  {
+    "id": 3859,
+    "series": "connection, unforeseen",
+    "series_index": 1.0
+  },
+  {
+    "id": 3862,
+    "series": "frayed",
+    "series_index": 5.0
+  },
+  {
+    "id": 3866,
+    "series": "held my burning heart",
+    "series_index": 5.0
+  },
+  {
+    "id": 3867,
+    "series": "truth or dare",
+    "series_index": 2.0
+  },
+  {
+    "id": 3870,
+    "series": "reclaim the rising",
+    "series_index": 9.0
+  },
+  {
+    "id": 3871,
+    "series": "it's worth it every time",
+    "series_index": 3.0
+  },
+  {
+    "id": 3873,
+    "series": "if living can be this",
+    "series_index": 2.0
+  },
+  {
+    "id": 3878,
+    "series": "More Than You Know",
+    "series_index": 2.0
+  },
+  {
+    "id": 3885,
+    "series": "JGY month 2021",
+    "series_index": 1.0
+  },
+  {
+    "id": 3889,
+    "series": "connection, unforeseen",
+    "series_index": 2.0
+  },
+  {
+    "id": 3890,
+    "series": "held my burning heart",
+    "series_index": 6.0
+  },
+  {
+    "id": 3893,
+    "series": "MDZS Drabbles",
+    "series_index": 1.0
+  },
+  {
+    "id": 3902,
+    "series": "held my burning heart",
+    "series_index": 7.0
+  },
+  {
+    "id": 3904,
+    "series": "connection, unforeseen",
+    "series_index": 3.0
+  },
+  {
+    "id": 3910,
+    "series": "The Other End of the Sky",
+    "series_index": 2.0
+  },
+  {
+    "id": 3915,
+    "series": "silt, or scurvy",
+    "series_index": 2.0
+  },
+  {
+    "id": 3920,
+    "series": "Westie's Art",
+    "series_index": 3.0
+  },
+  {
+    "id": 3923,
+    "series": "Fuck Around and Find Out",
+    "series_index": 3.0
+  },
+  {
+    "id": 3929,
+    "series": "Author's Favorites",
+    "series_index": 5.0
+  },
+  {
+    "id": 3930,
+    "series": "Acespec Chengning",
+    "series_index": 2.0
+  },
+  {
+    "id": 3931,
+    "series": "Wei Wuxian Makes a Wish",
+    "series_index": 2.0
+  },
+  {
+    "id": 3941,
+    "series": "Professional Griefers",
+    "series_index": 4.0
+  },
+  {
+    "id": 3945,
+    "series": "connection, unforeseen",
+    "series_index": 4.0
+  },
+  {
+    "id": 3951,
+    "series": "Ways of Looking at a Blackbird",
+    "series_index": 4.0
+  },
+  {
+    "id": 3952,
+    "series": "\u8f69\u626c\u6492\u624b (on the edge of this cliff, and i'm letting go)",
+    "series_index": 2.0
+  },
+  {
+    "id": 3960,
+    "series": "Total Power Exchange",
+    "series_index": 1.0
+  },
+  {
+    "id": 3961,
+    "series": "When Evening Comes",
+    "series_index": 1.0
+  },
+  {
+    "id": 3962,
+    "series": "Need It Or Not",
+    "series_index": 2.0
+  },
+  {
+    "id": 3969,
+    "series": "Total Power Exchange",
+    "series_index": 2.0
+  },
+  {
+    "id": 3970,
+    "series": "meet me back by the sea",
+    "series_index": 2.0
+  },
+  {
+    "id": 3972,
+    "series": "connection, unforeseen",
+    "series_index": 5.0
+  },
+  {
+    "id": 3976,
+    "series": "JGY month 2021",
+    "series_index": 2.0
+  },
+  {
+    "id": 3982,
+    "series": "if living can be this",
+    "series_index": 3.0
+  },
+  {
+    "id": 3983,
+    "series": "Plant Times with Wangxian",
+    "series_index": 1.0
+  },
+  {
+    "id": 3985,
+    "series": "famine foods",
+    "series_index": 1.0
+  },
+  {
+    "id": 3993,
+    "series": "like the other boys do",
+    "series_index": 8.0
+  },
+  {
+    "id": 3996,
+    "series": "still breathing",
+    "series_index": 2.0
+  },
+  {
+    "id": 4001,
+    "series": "held my burning heart",
+    "series_index": 8.0
+  },
+  {
+    "id": 4002,
+    "series": "held my burning heart",
+    "series_index": 9.0
+  },
+  {
+    "id": 4003,
+    "series": "Plant Times with Wangxian",
+    "series_index": 4.0
+  },
+  {
+    "id": 4004,
+    "series": "Miscellanous MXTX Fics (SVSSS, MDZS, TGCF)",
+    "series_index": 1.0
+  },
+  {
+    "id": 4005,
+    "series": "JGY month 2021",
+    "series_index": 3.0
+  },
+  {
+    "id": 4007,
+    "series": "Stealing (15) Kisses in Cloud Recesses (and a few other places)",
+    "series_index": 3.0
+  },
+  {
+    "id": 4013,
+    "series": "Fix Huaisang's Life",
+    "series_index": 2.0
+  },
+  {
+    "id": 4015,
+    "series": "Hungarian Walnut Cookies Ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 4016,
+    "series": "after",
+    "series_index": 3.0
+  },
+  {
+    "id": 4017,
+    "series": "Hungarian Walnut Cookies Ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 4020,
+    "series": "our bodies as homes",
+    "series_index": 2.0
+  },
+  {
+    "id": 4022,
+    "series": "the best bakery in the city",
+    "series_index": 1.0
+  },
+  {
+    "id": 4023,
+    "series": "Condensationverse",
+    "series_index": 3.0
+  },
+  {
+    "id": 4024,
+    "series": "Hungarian Walnut Cookies Ficlets",
+    "series_index": 5.0
+  },
+  {
+    "id": 4025,
+    "series": "Hungarian Walnut Cookies Ficlets",
+    "series_index": 6.0
+  },
+  {
+    "id": 4026,
+    "series": "Hungarian Walnut Cookies Ficlets",
+    "series_index": 7.0
+  },
+  {
+    "id": 4027,
+    "series": "Hungarian Walnut Cookies Ficlets",
+    "series_index": 8.0
+  },
+  {
+    "id": 4028,
+    "series": "Hungarian Walnut Cookies Ficlets",
+    "series_index": 9.0
+  },
+  {
+    "id": 4029,
+    "series": "all the depths of us",
+    "series_index": 2.0
+  },
+  {
+    "id": 4034,
+    "series": "held my burning heart",
+    "series_index": 10.0
+  },
+  {
+    "id": 4040,
+    "series": "JTWYA-verse",
+    "series_index": 4.0
+  },
+  {
+    "id": 4043,
+    "series": "reclaim the rising",
+    "series_index": 1.0
+  },
+  {
+    "id": 4058,
+    "series": "our bodies as homes",
+    "series_index": 3.0
+  },
+  {
+    "id": 4066,
+    "series": "MDZS Drabbles",
+    "series_index": 2.0
+  },
+  {
+    "id": 4067,
+    "series": "constellations",
+    "series_index": 2.0
+  },
+  {
+    "id": 4068,
+    "series": "you got the best of my love",
+    "series_index": 4.0
+  },
+  {
+    "id": 4069,
+    "series": "everyone lives; everyone fucks",
+    "series_index": 2.0
+  },
+  {
+    "id": 4072,
+    "series": "reclaim the rising",
+    "series_index": 5.0
+  },
+  {
+    "id": 4085,
+    "series": "Killing Me For Mercy",
+    "series_index": 2.0
+  },
+  {
+    "id": 4087,
+    "series": "Plant Times with Wangxian",
+    "series_index": 5.0
+  },
+  {
+    "id": 4089,
+    "series": "Ingredients of Your Gift",
+    "series_index": 5.0
+  },
+  {
+    "id": 4097,
+    "series": "Fuck",
+    "series_index": 3.0
+  },
+  {
+    "id": 4099,
+    "series": "reclaim the rising",
+    "series_index": 11.0
+  },
+  {
+    "id": 4101,
+    "series": "the best bakery in the city",
+    "series_index": 2.0
+  },
+  {
+    "id": 4113,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 5.0
+  },
+  {
+    "id": 4119,
+    "series": "like the holes of your heart",
+    "series_index": 1.0
+  },
+  {
+    "id": 4121,
+    "series": "light it up and let it burn",
+    "series_index": 1.0
+  },
+  {
+    "id": 4123,
+    "series": "held my burning heart",
+    "series_index": 11.0
+  },
+  {
+    "id": 4129,
+    "series": "JTWYA-verse",
+    "series_index": 5.0
+  },
+  {
+    "id": 4133,
+    "series": "in a veil of great surprises",
+    "series_index": 3.0
+  },
+  {
+    "id": 4136,
+    "series": "we waste the same day (like nobody dies)",
+    "series_index": 1.0
+  },
+  {
+    "id": 4137,
+    "series": "it's worth it every time",
+    "series_index": 4.0
+  },
+  {
+    "id": 4142,
+    "series": "take me; take this",
+    "series_index": 10.0
+  },
+  {
+    "id": 4144,
+    "series": "Kinkmeme Fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 4148,
+    "series": "Stupid Love",
+    "series_index": 2.0
+  },
+  {
+    "id": 4150,
+    "series": "Surrender Sweetly",
+    "series_index": 4.0
+  },
+  {
+    "id": 4151,
+    "series": "like the holes of your heart",
+    "series_index": 2.0
+  },
+  {
+    "id": 4154,
+    "series": "The Children's Crusade",
+    "series_index": 1.0
+  },
+  {
+    "id": 4163,
+    "series": "somewhere i have never traveled,gladly beyond",
+    "series_index": 4.0
+  },
+  {
+    "id": 4165,
+    "series": "Gimme a Kiss?",
+    "series_index": 1.0
+  },
+  {
+    "id": 4166,
+    "series": "Gimme a Kiss?",
+    "series_index": 2.0
+  },
+  {
+    "id": 4167,
+    "series": "Gimme a Kiss?",
+    "series_index": 3.0
+  },
+  {
+    "id": 4170,
+    "series": "Be Good, Be Nice, Be Careful",
+    "series_index": 1.0
+  },
+  {
+    "id": 4181,
+    "series": "Bot's ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 4182,
+    "series": "Bot's ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 4183,
+    "series": "Bot's ficlets",
+    "series_index": 3.0
+  },
+  {
+    "id": 4195,
+    "series": "you're not alone",
+    "series_index": 1.0
+  },
+  {
+    "id": 4198,
+    "series": "Twitter Fics",
+    "series_index": 2.0
+  },
+  {
+    "id": 4199,
+    "series": "Shattered",
+    "series_index": 3.0
+  },
+  {
+    "id": 4200,
+    "series": "Fuck Around and Find Out",
+    "series_index": 4.0
+  },
+  {
+    "id": 4204,
+    "series": "Baby, you could fuck up my whole life",
+    "series_index": 3.0
+  },
+  {
+    "id": 4207,
+    "series": "put my mind at ease (pretty please)",
+    "series_index": 1.0
+  },
+  {
+    "id": 4209,
+    "series": "reclaim the rising",
+    "series_index": 12.0
+  },
+  {
+    "id": 4212,
+    "series": "you're not alone",
+    "series_index": 2.0
+  },
+  {
+    "id": 4213,
+    "series": "The Children's Crusade",
+    "series_index": 2.0
+  },
+  {
+    "id": 4221,
+    "series": "JTWYA-verse",
+    "series_index": 6.0
+  },
+  {
+    "id": 4222,
+    "series": "A capriccio",
+    "series_index": 1.0
+  },
+  {
+    "id": 4224,
+    "series": "our love is small yet shining",
+    "series_index": 1.0
+  },
+  {
+    "id": 4227,
+    "series": "Living and Dying and Living",
+    "series_index": 2.0
+  },
+  {
+    "id": 4231,
+    "series": "time, curious time",
+    "series_index": 2.0
+  },
+  {
+    "id": 4237,
+    "series": "XuanCheng Week",
+    "series_index": 1.0
+  },
+  {
+    "id": 4239,
+    "series": "like the setting sun",
+    "series_index": 6.0
+  },
+  {
+    "id": 4244,
+    "series": "figure you out",
+    "series_index": 1.0
+  },
+  {
+    "id": 4246,
+    "series": "light it up and let it burn",
+    "series_index": 2.0
+  },
+  {
+    "id": 4250,
+    "series": "figure you out",
+    "series_index": 2.0
+  },
+  {
+    "id": 4254,
+    "series": "Ephemera, archived",
+    "series_index": 1.0
+  },
+  {
+    "id": 4260,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 7.0
+  },
+  {
+    "id": 4266,
+    "series": "Gimme a Kiss?",
+    "series_index": 4.0
+  },
+  {
+    "id": 4273,
+    "series": "a series of firsts",
+    "series_index": 1.0
+  },
+  {
+    "id": 4276,
+    "series": "Ingredients of Your Gift",
+    "series_index": 6.0
+  },
+  {
+    "id": 4278,
+    "series": "ranwan mob au",
+    "series_index": 1.0
+  },
+  {
+    "id": 4280,
+    "series": "some things stick",
+    "series_index": 1.0
+  },
+  {
+    "id": 4281,
+    "series": "Plant Times with Wangxian",
+    "series_index": 6.0
+  },
+  {
+    "id": 4292,
+    "series": "forever may you reign",
+    "series_index": 1.0
+  },
+  {
+    "id": 4295,
+    "series": "The Children's Crusade",
+    "series_index": 3.0
+  },
+  {
+    "id": 4298,
+    "series": "some things stick",
+    "series_index": 2.0
+  },
+  {
+    "id": 4299,
+    "series": "Immortal Cultivators Shenanigans",
+    "series_index": 1.0
+  },
+  {
+    "id": 4303,
+    "series": "how bold I was",
+    "series_index": 1.0
+  },
+  {
+    "id": 4304,
+    "series": "no one calls you honey when you're sitting on a throne",
+    "series_index": 3.0
+  },
+  {
+    "id": 4305,
+    "series": "a series of firsts",
+    "series_index": 2.0
+  },
+  {
+    "id": 4310,
+    "series": "like the other boys do",
+    "series_index": 9.0
+  },
+  {
+    "id": 4311,
+    "series": "if living can be this",
+    "series_index": 4.0
+  },
+  {
+    "id": 4312,
+    "series": "a series of firsts",
+    "series_index": 3.0
+  },
+  {
+    "id": 4315,
+    "series": "we waste the same day (like nobody dies)",
+    "series_index": 2.0
+  },
+  {
+    "id": 4330,
+    "series": "loose ends verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 4334,
+    "series": "Your Life Again, Your Life Anew",
+    "series_index": 3.0
+  },
+  {
+    "id": 4336,
+    "series": "Twitter Fics",
+    "series_index": 4.0
+  },
+  {
+    "id": 4337,
+    "series": "our love is small yet shining",
+    "series_index": 2.0
+  },
+  {
+    "id": 4339,
+    "series": "our love is small yet shining",
+    "series_index": 3.0
+  },
+  {
+    "id": 4340,
+    "series": "if living can be this",
+    "series_index": 6.0
+  },
+  {
+    "id": 4341,
+    "series": "Yunmeng Trio Body Mod Trilogy",
+    "series_index": 1.0
+  },
+  {
+    "id": 4342,
+    "series": "Yunmeng Trio Body Mod Trilogy",
+    "series_index": 2.0
+  },
+  {
+    "id": 4343,
+    "series": "Yunmeng Trio Body Mod Trilogy",
+    "series_index": 3.0
+  },
+  {
+    "id": 4362,
+    "series": "our close and kindred ties",
+    "series_index": 6.0
+  },
+  {
+    "id": 4363,
+    "series": "our love is small yet shining",
+    "series_index": 4.0
+  },
+  {
+    "id": 4374,
+    "series": "a series of firsts",
+    "series_index": 4.0
+  },
+  {
+    "id": 4376,
+    "series": "loose ends verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 4382,
+    "series": "A capriccio",
+    "series_index": 2.0
+  },
+  {
+    "id": 4395,
+    "series": "Wanxin's mdzs kink meme fills",
+    "series_index": 4.0
+  },
+  {
+    "id": 4402,
+    "series": "Twitter Fics",
+    "series_index": 5.0
+  },
+  {
+    "id": 4406,
+    "series": "Recovery",
+    "series_index": 2.0
+  },
+  {
+    "id": 4407,
+    "series": "Inside the Mind of a Man is a Massacre",
+    "series_index": 1.0
+  },
+  {
+    "id": 4415,
+    "series": "Jing'an-junzhu Lives AU (jal au)",
+    "series_index": 1.0
+  },
+  {
+    "id": 4416,
+    "series": "Our Wretched Fates",
+    "series_index": 1.0
+  },
+  {
+    "id": 4425,
+    "series": "atop snowcapped mountains",
+    "series_index": 1.0
+  },
+  {
+    "id": 4427,
+    "series": "Recovery",
+    "series_index": 3.0
+  },
+  {
+    "id": 4431,
+    "series": "some things stick",
+    "series_index": 3.0
+  },
+  {
+    "id": 4435,
+    "series": "White moon, green world",
+    "series_index": 1.0
+  },
+  {
+    "id": 4442,
+    "series": "JTWYA-verse",
+    "series_index": 7.0
+  },
+  {
+    "id": 4451,
+    "series": "Distant Shores and Voices",
+    "series_index": 13.0
+  },
+  {
+    "id": 4453,
+    "series": "figure you out",
+    "series_index": 3.0
+  },
+  {
+    "id": 4458,
+    "series": "MDZS Drabbles",
+    "series_index": 4.0
+  },
+  {
+    "id": 4459,
+    "series": "Fix Huaisang's Life",
+    "series_index": 3.0
+  },
+  {
+    "id": 4462,
+    "series": "Odd Jobs",
+    "series_index": 1.0
+  },
+  {
+    "id": 4466,
+    "series": "how bold I was",
+    "series_index": 2.0
+  },
+  {
+    "id": 4467,
+    "series": "White moon, green world",
+    "series_index": 2.0
+  },
+  {
+    "id": 4475,
+    "series": "Inside the Mind of a Man is a Massacre",
+    "series_index": 3.0
+  },
+  {
+    "id": 4484,
+    "series": "the lost colony",
+    "series_index": 1.0
+  },
+  {
+    "id": 4489,
+    "series": "A Star to Steer By",
+    "series_index": 10.0
+  },
+  {
+    "id": 4490,
+    "series": "Vilified, Crucified",
+    "series_index": 1.0
+  },
+  {
+    "id": 4491,
+    "series": "silver clouds, grey linings",
+    "series_index": 3.0
+  },
+  {
+    "id": 4496,
+    "series": "frayed",
+    "series_index": 6.0
+  },
+  {
+    "id": 4499,
+    "series": "silver clouds, grey linings",
+    "series_index": 2.0
+  },
+  {
+    "id": 4511,
+    "series": "our love is small yet shining",
+    "series_index": 5.0
+  },
+  {
+    "id": 4514,
+    "series": "a series of firsts",
+    "series_index": 5.0
+  },
+  {
+    "id": 4533,
+    "series": "\u8ab0\u8b02\u6cb3\u5ee3\u3001\u4e00\u8466\u676d\u4e4b | who says the river is wide (or, Lan Fangji)",
+    "series_index": 3.0
+  },
+  {
+    "id": 4537,
+    "series": "silver clouds, grey linings",
+    "series_index": 4.0
+  },
+  {
+    "id": 4539,
+    "series": "To be a pair of butterflies",
+    "series_index": 2.0
+  },
+  {
+    "id": 4541,
+    "series": "our love is small yet shining",
+    "series_index": 6.0
+  },
+  {
+    "id": 4545,
+    "series": "silver clouds, grey linings",
+    "series_index": 1.0
+  },
+  {
+    "id": 4553,
+    "series": "Unrelated short fics about the women of CQL/The Untamed",
+    "series_index": 8.0
+  },
+  {
+    "id": 4569,
+    "series": "Vilified, Crucified",
+    "series_index": 2.0
+  },
+  {
+    "id": 4572,
+    "series": "we waste the same day like nobody dies",
+    "series_index": 3.0
+  },
+  {
+    "id": 4575,
+    "series": "Friday I'm In Love",
+    "series_index": 2.0
+  },
+  {
+    "id": 4586,
+    "series": "silver clouds, grey linings",
+    "series_index": 5.0
+  },
+  {
+    "id": 4591,
+    "series": "Making Room",
+    "series_index": 4.0
+  },
+  {
+    "id": 4593,
+    "series": "junzhe stories in 1,000 words or less",
+    "series_index": 1.0
+  },
+  {
+    "id": 4594,
+    "series": "junzhe stories in 1,000 words or less",
+    "series_index": 2.0
+  },
+  {
+    "id": 4602,
+    "series": "Our Wretched Fates",
+    "series_index": 2.0
+  },
+  {
+    "id": 4610,
+    "series": "junzhe stories in 1,000 words or less",
+    "series_index": 3.0
+  },
+  {
+    "id": 4611,
+    "series": "junzhe stories in 1,000 words or less",
+    "series_index": 4.0
+  },
+  {
+    "id": 4612,
+    "series": "junzhe stories in 1,000 words or less",
+    "series_index": 5.0
+  },
+  {
+    "id": 4615,
+    "series": "Twitter Fics",
+    "series_index": 6.0
+  },
+  {
+    "id": 4627,
+    "series": "junzhe stories in 1,000 words or less",
+    "series_index": 6.0
+  },
+  {
+    "id": 4632,
+    "series": "murderverse",
+    "series_index": 2.0
+  },
+  {
+    "id": 4634,
+    "series": "you're not alone",
+    "series_index": 3.0
+  },
+  {
+    "id": 4636,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 71.0
+  },
+  {
+    "id": 4637,
+    "series": "Bot's ficlets",
+    "series_index": 4.0
+  },
+  {
+    "id": 4638,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 1.0
+  },
+  {
+    "id": 4639,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 2.0
+  },
+  {
+    "id": 4640,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 3.0
+  },
+  {
+    "id": 4641,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 4.0
+  },
+  {
+    "id": 4642,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 5.0
+  },
+  {
+    "id": 4643,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 6.0
+  },
+  {
+    "id": 4644,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 7.0
+  },
+  {
+    "id": 4645,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 8.0
+  },
+  {
+    "id": 4646,
+    "series": "ZhuHan Canon-ish 'Verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 4648,
+    "series": "Author's Favorites",
+    "series_index": 10.0
+  },
+  {
+    "id": 4649,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 10.0
+  },
+  {
+    "id": 4651,
+    "series": "if living can be this",
+    "series_index": 5.0
+  },
+  {
+    "id": 4653,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 11.0
+  },
+  {
+    "id": 4655,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 12.0
+  },
+  {
+    "id": 4656,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 13.0
+  },
+  {
+    "id": 4657,
+    "series": "Fuck",
+    "series_index": 4.0
+  },
+  {
+    "id": 4658,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 15.0
+  },
+  {
+    "id": 4662,
+    "series": "tumblr drabbles",
+    "series_index": 11.0
+  },
+  {
+    "id": 4663,
+    "series": "Give a Little",
+    "series_index": 4.0
+  },
+  {
+    "id": 4664,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 17.0
+  },
+  {
+    "id": 4665,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 18.0
+  },
+  {
+    "id": 4667,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 19.0
+  },
+  {
+    "id": 4668,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 20.0
+  },
+  {
+    "id": 4674,
+    "series": "The Children's Crusade",
+    "series_index": 4.0
+  },
+  {
+    "id": 4676,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 21.0
+  },
+  {
+    "id": 4677,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 22.0
+  },
+  {
+    "id": 4678,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 23.0
+  },
+  {
+    "id": 4679,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 24.0
+  },
+  {
+    "id": 4681,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 25.0
+  },
+  {
+    "id": 4684,
+    "series": "Like an old brocade, like new pearls",
+    "series_index": 1.0
+  },
+  {
+    "id": 4687,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 26.0
+  },
+  {
+    "id": 4688,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 27.0
+  },
+  {
+    "id": 4689,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 28.0
+  },
+  {
+    "id": 4690,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 29.0
+  },
+  {
+    "id": 4691,
+    "series": "Pride Month Shortfics 2021",
+    "series_index": 30.0
+  },
+  {
+    "id": 4693,
+    "series": "silver clouds, grey linings",
+    "series_index": 6.0
+  },
+  {
+    "id": 4698,
+    "series": "Inside the Mind of a Man is a Massacre",
+    "series_index": 2.0
+  },
+  {
+    "id": 4709,
+    "series": "pinpricks of light, all bound up in you",
+    "series_index": 5.0
+  },
+  {
+    "id": 4715,
+    "series": "silver clouds, grey linings",
+    "series_index": 7.0
+  },
+  {
+    "id": 4716,
+    "series": "Odd Jobs",
+    "series_index": 2.0
+  },
+  {
+    "id": 4718,
+    "series": "Signature Blend (VC Coffee Shop AU)",
+    "series_index": 3.0
+  },
+  {
+    "id": 4721,
+    "series": "Friday I'm In Love",
+    "series_index": 1.0
+  },
+  {
+    "id": 4726,
+    "series": "three's a crowd, four's a party",
+    "series_index": 2.0
+  },
+  {
+    "id": 4737,
+    "series": "figure you out",
+    "series_index": 4.0
+  },
+  {
+    "id": 4741,
+    "series": "given the histories of you and you",
+    "series_index": 1.0
+  },
+  {
+    "id": 4742,
+    "series": "if living can be this",
+    "series_index": 6.0
+  },
+  {
+    "id": 4744,
+    "series": "Grooming",
+    "series_index": 1.0
+  },
+  {
+    "id": 4748,
+    "series": "silver clouds, grey linings",
+    "series_index": 8.0
+  },
+  {
+    "id": 4761,
+    "series": "Gimme a Kiss?",
+    "series_index": 5.0
+  },
+  {
+    "id": 4766,
+    "series": "Grooming",
+    "series_index": 2.0
+  },
+  {
+    "id": 4768,
+    "series": "in search of the moon (sms time travel 'verse)",
+    "series_index": 1.0
+  },
+  {
+    "id": 4771,
+    "series": "silver clouds, grey linings",
+    "series_index": 9.0
+  },
+  {
+    "id": 4775,
+    "series": "throwing off sparks",
+    "series_index": 2.0
+  },
+  {
+    "id": 4778,
+    "series": "Twitter Fics",
+    "series_index": 7.0
+  },
+  {
+    "id": 4780,
+    "series": "Wish upon a starfish (meryao)",
+    "series_index": 1.0
+  },
+  {
+    "id": 4786,
+    "series": "reclaim the rising",
+    "series_index": 3.0
+  },
+  {
+    "id": 4789,
+    "series": "silver clouds, grey linings",
+    "series_index": 10.0
+  },
+  {
+    "id": 4791,
+    "series": "Ephemera, archived",
+    "series_index": 2.0
+  },
+  {
+    "id": 4793,
+    "series": "Ephemera, archived",
+    "series_index": 3.0
+  },
+  {
+    "id": 4796,
+    "series": "lessons",
+    "series_index": 2.0
+  },
+  {
+    "id": 4819,
+    "series": "Ephemera, archived",
+    "series_index": 4.0
+  },
+  {
+    "id": 4820,
+    "series": "Ephemera, archived",
+    "series_index": 5.0
+  },
+  {
+    "id": 4827,
+    "series": "Grooming",
+    "series_index": 3.0
+  },
+  {
+    "id": 4833,
+    "series": "MDZS Drabbles",
+    "series_index": 5.0
+  },
+  {
+    "id": 4834,
+    "series": "Ephemera, archived",
+    "series_index": 6.0
+  },
+  {
+    "id": 4839,
+    "series": "if you tell them where to begin",
+    "series_index": 2.0
+  },
+  {
+    "id": 4840,
+    "series": "reclaim the rising",
+    "series_index": 10.0
+  },
+  {
+    "id": 4851,
+    "series": "femslash friday fills",
+    "series_index": 1.0
+  },
+  {
+    "id": 4854,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 72.0
+  },
+  {
+    "id": 4861,
+    "series": "loose ends verse",
+    "series_index": 4.0
+  },
+  {
+    "id": 4863,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 14.0
+  },
+  {
+    "id": 4865,
+    "series": "impetus",
+    "series_index": 1.0
+  },
+  {
+    "id": 4882,
+    "series": "Remember This Cold",
+    "series_index": 75.0
+  },
+  {
+    "id": 4885,
+    "series": "Ephemera, archived",
+    "series_index": 7.0
+  },
+  {
+    "id": 4887,
+    "series": "Ingredients of Your Gift",
+    "series_index": 7.0
+  },
+  {
+    "id": 4888,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 6.0
+  },
+  {
+    "id": 4894,
+    "series": "Tianchuang Era Zhou Zishu One-shots",
+    "series_index": 1.0
+  },
+  {
+    "id": 4901,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 32.0
+  },
+  {
+    "id": 4906,
+    "series": "Threadfic Archive",
+    "series_index": 1.0
+  },
+  {
+    "id": 4907,
+    "series": "Threadfic Archive",
+    "series_index": 2.0
+  },
+  {
+    "id": 4909,
+    "series": "Threadfic Archive",
+    "series_index": 3.0
+  },
+  {
+    "id": 4919,
+    "series": "where you are, that's where i'll be / \u4f60\u5728\u6211\u4e5f\u5728",
+    "series_index": 1.0
+  },
+  {
+    "id": 4920,
+    "series": "Distant Shores and Voices",
+    "series_index": 14.0
+  },
+  {
+    "id": 4925,
+    "series": "Crack Fic Central",
+    "series_index": 4.0
+  },
+  {
+    "id": 4933,
+    "series": "PTA-verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 4934,
+    "series": "Ephemera, archived",
+    "series_index": 8.0
+  },
+  {
+    "id": 4938,
+    "series": "Tianchuang Era Zhou Zishu One-shots",
+    "series_index": 2.0
+  },
+  {
+    "id": 4941,
+    "series": "[to see you there]",
+    "series_index": 15.0
+  },
+  {
+    "id": 4945,
+    "series": "if living can be this",
+    "series_index": 8.0
+  },
+  {
+    "id": 4946,
+    "series": "Bot's ficlets",
+    "series_index": 6.0
+  },
+  {
+    "id": 4947,
+    "series": "Tianchuang Era Zhou Zishu One-shots",
+    "series_index": 3.0
+  },
+  {
+    "id": 4950,
+    "series": "Twitter Fics",
+    "series_index": 8.0
+  },
+  {
+    "id": 4951,
+    "series": "[to see you there]",
+    "series_index": 16.0
+  },
+  {
+    "id": 4953,
+    "series": "drabbles",
+    "series_index": 22.0
+  },
+  {
+    "id": 4963,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 38.0
+  },
+  {
+    "id": 4965,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 40.0
+  },
+  {
+    "id": 4966,
+    "series": "Remember This Cold",
+    "series_index": 29.0
+  },
+  {
+    "id": 4969,
+    "series": "BDSM AU",
+    "series_index": 4.0
+  },
+  {
+    "id": 4983,
+    "series": "BDSM AU",
+    "series_index": 5.0
+  },
+  {
+    "id": 4989,
+    "series": "Ephemera, archived",
+    "series_index": 9.0
+  },
+  {
+    "id": 4991,
+    "series": "Yexie Week 2021",
+    "series_index": 1.0
+  },
+  {
+    "id": 4993,
+    "series": "Tianchuang Era Zhou Zishu One-shots",
+    "series_index": 4.0
+  },
+  {
+    "id": 4994,
+    "series": "people we could have been",
+    "series_index": 3.0
+  },
+  {
+    "id": 4996,
+    "series": "Misadventures at MXTX University",
+    "series_index": 1.0
+  },
+  {
+    "id": 4997,
+    "series": "flight of a one-winged dove",
+    "series_index": 2.0
+  },
+  {
+    "id": 4998,
+    "series": "a series of firsts",
+    "series_index": 6.0
+  },
+  {
+    "id": 4999,
+    "series": "Yexie Week 2021",
+    "series_index": 2.0
+  },
+  {
+    "id": 5002,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 66.0
+  },
+  {
+    "id": 5006,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 73.0
+  },
+  {
+    "id": 5010,
+    "series": "Vibes and Biting (the Lanpire AU)",
+    "series_index": 1.0
+  },
+  {
+    "id": 5013,
+    "series": "Whumptober 2021: Yi City Edition",
+    "series_index": 1.0
+  },
+  {
+    "id": 5014,
+    "series": "throwing off sparks",
+    "series_index": 3.0
+  },
+  {
+    "id": 5017,
+    "series": "Mount Taicang",
+    "series_index": 2.0
+  },
+  {
+    "id": 5020,
+    "series": "Tianchuang-tober and Han Ying's Sexy Education in Tianchuang Techniques",
+    "series_index": 1.0
+  },
+  {
+    "id": 5022,
+    "series": "Dark Month 2021",
+    "series_index": 1.0
+  },
+  {
+    "id": 5023,
+    "series": "Kinktober 2021",
+    "series_index": 1.0
+  },
+  {
+    "id": 5026,
+    "series": "Kinktober 2021",
+    "series_index": 2.0
+  },
+  {
+    "id": 5028,
+    "series": "Kinktober 2021",
+    "series_index": 3.0
+  },
+  {
+    "id": 5029,
+    "series": "Kinktober 2021",
+    "series_index": 4.0
+  },
+  {
+    "id": 5030,
+    "series": "Tianchuang-tober and Han Ying's Sexy Education in Tianchuang Techniques",
+    "series_index": 2.0
+  },
+  {
+    "id": 5031,
+    "series": "Whumptober 2021: Yi City Edition",
+    "series_index": 2.0
+  },
+  {
+    "id": 5034,
+    "series": "Kinktober 2021",
+    "series_index": 5.0
+  },
+  {
+    "id": 5035,
+    "series": "figure you out",
+    "series_index": 5.0
+  },
+  {
+    "id": 5036,
+    "series": "Whumptober 2021: Yi City Edition",
+    "series_index": 3.0
+  },
+  {
+    "id": 5037,
+    "series": "sv fics (83.33% moshang)",
+    "series_index": 2.0
+  },
+  {
+    "id": 5039,
+    "series": "Kinktober 2021",
+    "series_index": 6.0
+  },
+  {
+    "id": 5040,
+    "series": "medicine and poison",
+    "series_index": 2.0
+  },
+  {
+    "id": 5041,
+    "series": "Whumptober 2021: Yi City Edition",
+    "series_index": 4.0
+  },
+  {
+    "id": 5044,
+    "series": "Kinktober 2021",
+    "series_index": 7.0
+  },
+  {
+    "id": 5047,
+    "series": "Tianchuang Era Zhou Zishu One-shots",
+    "series_index": 7.0
+  },
+  {
+    "id": 5049,
+    "series": "Kinktober 2021",
+    "series_index": 8.0
+  },
+  {
+    "id": 5050,
+    "series": "Remember This Cold",
+    "series_index": 76.0
+  },
+  {
+    "id": 5055,
+    "series": "Kinktober 2021",
+    "series_index": 9.0
+  },
+  {
+    "id": 5056,
+    "series": "isn't it pretty to think",
+    "series_index": 1.0
+  },
+  {
+    "id": 5058,
+    "series": "the best bakery in the city",
+    "series_index": 3.0
+  },
+  {
+    "id": 5061,
+    "series": "Kinktober 2021",
+    "series_index": 10.0
+  },
+  {
+    "id": 5064,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 68.0
+  },
+  {
+    "id": 5067,
+    "series": "Kinktober 2021",
+    "series_index": 11.0
+  },
+  {
+    "id": 5071,
+    "series": "Tianchuang-tober and Han Ying's Sexy Education in Tianchuang Techniques",
+    "series_index": 4.0
+  },
+  {
+    "id": 5073,
+    "series": "Kinktober 2021",
+    "series_index": 12.0
+  },
+  {
+    "id": 5081,
+    "series": "Kinktober 2021",
+    "series_index": 13.0
+  },
+  {
+    "id": 5084,
+    "series": "Kinktober 2021",
+    "series_index": 14.0
+  },
+  {
+    "id": 5086,
+    "series": "Kinktober 2021",
+    "series_index": 15.0
+  },
+  {
+    "id": 5088,
+    "series": "Whumptober 2021: Yi City Edition",
+    "series_index": 5.0
+  },
+  {
+    "id": 5090,
+    "series": "Kinktober 2021",
+    "series_index": 16.0
+  },
+  {
+    "id": 5092,
+    "series": "light it up and let it burn",
+    "series_index": 3.0
+  },
+  {
+    "id": 5093,
+    "series": "Twitter Fics",
+    "series_index": 9.0
+  },
+  {
+    "id": 5094,
+    "series": "Infinite Coffee and Protection Detail",
+    "series_index": 2.0
+  },
+  {
+    "id": 5096,
+    "series": "Ingredients of Your Gift",
+    "series_index": 8.0
+  },
+  {
+    "id": 5097,
+    "series": "Kinktober 2021",
+    "series_index": 17.0
+  },
+  {
+    "id": 5098,
+    "series": "Kinktober 2021",
+    "series_index": 18.0
+  },
+  {
+    "id": 5101,
+    "series": "Kinktober 2021",
+    "series_index": 19.0
+  },
+  {
+    "id": 5103,
+    "series": "connection, unforeseen",
+    "series_index": 6.0
+  },
+  {
+    "id": 5104,
+    "series": "impetus",
+    "series_index": 2.0
+  },
+  {
+    "id": 5106,
+    "series": "Kinktober 2021",
+    "series_index": 20.0
+  },
+  {
+    "id": 5107,
+    "series": "light it up and let it burn",
+    "series_index": 4.0
+  },
+  {
+    "id": 5110,
+    "series": "Kinktober 2021",
+    "series_index": 21.0
+  },
+  {
+    "id": 5112,
+    "series": "canon compliant sv fics (71.43% moshang)",
+    "series_index": 7.0
+  },
+  {
+    "id": 5114,
+    "series": "Kinktober 2021",
+    "series_index": 22.0
+  },
+  {
+    "id": 5124,
+    "series": "Kinktober 2021",
+    "series_index": 23.0
+  },
+  {
+    "id": 5127,
+    "series": "Halloween treats 2021",
+    "series_index": 2.0
+  },
+  {
+    "id": 5131,
+    "series": "Kinktober 2021",
+    "series_index": 24.0
+  },
+  {
+    "id": 5135,
+    "series": "ignite",
+    "series_index": 1.0
+  },
+  {
+    "id": 5138,
+    "series": "Kinktober 2021",
+    "series_index": 25.0
+  },
+  {
+    "id": 5140,
+    "series": "Halloween treats 2021",
+    "series_index": 1.0
+  },
+  {
+    "id": 5143,
+    "series": "Kinktober 2021",
+    "series_index": 26.0
+  },
+  {
+    "id": 5147,
+    "series": "Kinktober 2021",
+    "series_index": 27.0
+  },
+  {
+    "id": 5150,
+    "series": "Halloween trick or treating 2021",
+    "series_index": 3.0
+  },
+  {
+    "id": 5152,
+    "series": "Kinktober 2021",
+    "series_index": 28.0
+  },
+  {
+    "id": 5159,
+    "series": "fridge deer",
+    "series_index": 2.0
+  },
+  {
+    "id": 5160,
+    "series": "JTWYA-verse",
+    "series_index": 9.0
+  },
+  {
+    "id": 5166,
+    "series": "Grim Tales",
+    "series_index": 8.0
+  },
+  {
+    "id": 5169,
+    "series": "impetus",
+    "series_index": 3.0
+  },
+  {
+    "id": 5170,
+    "series": "2ha drabbles and ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 5172,
+    "series": "Kinktober 2021",
+    "series_index": 30.0
+  },
+  {
+    "id": 5173,
+    "series": "Remember This Cold",
+    "series_index": 32.0
+  },
+  {
+    "id": 5177,
+    "series": "Whumptober 2021: Yi City Edition",
+    "series_index": 6.0
+  },
+  {
+    "id": 5178,
+    "series": "Kinktober 2021",
+    "series_index": 31.0
+  },
+  {
+    "id": 5184,
+    "series": "Ephemera, archived",
+    "series_index": 10.0
+  },
+  {
+    "id": 5197,
+    "series": "[to see you there]",
+    "series_index": 20.0
+  },
+  {
+    "id": 5201,
+    "series": "medicine and poison",
+    "series_index": 3.0
+  },
+  {
+    "id": 5209,
+    "series": "2ha drabbles and ficlets",
+    "series_index": 3.0
+  },
+  {
+    "id": 5230,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 46.0
+  },
+  {
+    "id": 5231,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 75.0
+  },
+  {
+    "id": 5233,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 13.0
+  },
+  {
+    "id": 5241,
+    "series": "Necrophilia",
+    "series_index": 1.0
+  },
+  {
+    "id": 5242,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 74.0
+  },
+  {
+    "id": 5247,
+    "series": "Kings County",
+    "series_index": 2.0
+  },
+  {
+    "id": 5259,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 78.0
+  },
+  {
+    "id": 5260,
+    "series": "Odd Jobs",
+    "series_index": 3.0
+  },
+  {
+    "id": 5263,
+    "series": "In Which Tony Stark Builds Himself Some Friends (But His Family Was Assigned by Nick Fury)",
+    "series_index": 7.0
+  },
+  {
+    "id": 5276,
+    "series": "growing stronger",
+    "series_index": 2.0
+  },
+  {
+    "id": 5277,
+    "series": "it's just like we were meant to be",
+    "series_index": 2.0
+  },
+  {
+    "id": 5284,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 51.0
+  },
+  {
+    "id": 5285,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 69.0
+  },
+  {
+    "id": 5289,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 60.0
+  },
+  {
+    "id": 5293,
+    "series": "Necrophilia",
+    "series_index": 2.0
+  },
+  {
+    "id": 5310,
+    "series": "Charmbreaker.",
+    "series_index": 1.0
+  },
+  {
+    "id": 5311,
+    "series": "Charmbreaker.",
+    "series_index": 2.0
+  },
+  {
+    "id": 5333,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 64.0
+  },
+  {
+    "id": 5336,
+    "series": "Gulfport: A British Petroleum Fanfic",
+    "series_index": 1.0
+  },
+  {
+    "id": 5338,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 6.0
+  },
+  {
+    "id": 5340,
+    "series": "In Which Tony Stark Builds Himself Some Friends (But His Family Was Assigned by Nick Fury)",
+    "series_index": 1.0
+  },
+  {
+    "id": 5352,
+    "series": "[to see you there]",
+    "series_index": 12.0
+  },
+  {
+    "id": 5353,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 77.0
+  },
+  {
+    "id": 5355,
+    "series": "In Which Tony Stark Builds Himself Some Friends (But His Family Was Assigned by Nick Fury)",
+    "series_index": 2.0
+  },
+  {
+    "id": 5356,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 76.0
+  },
+  {
+    "id": 5361,
+    "series": "In Which Tony Stark Builds Himself Some Friends (But His Family Was Assigned by Nick Fury)",
+    "series_index": 3.0
+  },
+  {
+    "id": 5366,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 14.0
+  },
+  {
+    "id": 5377,
+    "series": "Beneath the Trees 'verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 5388,
+    "series": "Beneath the Trees 'verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 5389,
+    "series": "Beneath the Trees 'verse",
+    "series_index": 3.0
+  },
+  {
+    "id": 5399,
+    "series": "Beneath the Trees 'verse",
+    "series_index": 4.0
+  },
+  {
+    "id": 5415,
+    "series": "Beneath the Trees 'verse",
+    "series_index": 5.0
+  },
+  {
+    "id": 5437,
+    "series": "[to see you there]",
+    "series_index": 5.0
+  },
+  {
+    "id": 5438,
+    "series": "[to see you there]",
+    "series_index": 18.0
+  },
+  {
+    "id": 5440,
+    "series": "it's just like we were meant to be",
+    "series_index": 1.0
+  },
+  {
+    "id": 5441,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 17.0
+  },
+  {
+    "id": 5447,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 15.0
+  },
+  {
+    "id": 5451,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 70.0
+  },
+  {
+    "id": 5452,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 82.0
+  },
+  {
+    "id": 5454,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 79.0
+  },
+  {
+    "id": 5457,
+    "series": "Thor Works",
+    "series_index": 1.0
+  },
+  {
+    "id": 5460,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 83.0
+  },
+  {
+    "id": 5462,
+    "series": "[to see you there]",
+    "series_index": 8.0
+  },
+  {
+    "id": 5464,
+    "series": "Remember This Cold",
+    "series_index": 1.0
+  },
+  {
+    "id": 5465,
+    "series": "Remember This Cold",
+    "series_index": 34.0
+  },
+  {
+    "id": 5467,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 12.0
+  },
+  {
+    "id": 5469,
+    "series": "princess Jay",
+    "series_index": 5.0
+  },
+  {
+    "id": 5471,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 84.0
+  },
+  {
+    "id": 5477,
+    "series": "[to see you there]",
+    "series_index": 24.0
+  },
+  {
+    "id": 5484,
+    "series": "Infinite Coffee and Protection Detail",
+    "series_index": 4.0
+  },
+  {
+    "id": 5485,
+    "series": "The One Where Loki and Steve Might Be Friends (sort of)",
+    "series_index": 1.0
+  },
+  {
+    "id": 5486,
+    "series": "little beasts",
+    "series_index": 46.0
+  },
+  {
+    "id": 5503,
+    "series": "The One Where Loki and Steve Might Be Friends (sort of)",
+    "series_index": 2.0
+  },
+  {
+    "id": 5506,
+    "series": "little beasts",
+    "series_index": 56.0
+  },
+  {
+    "id": 5507,
+    "series": "Author's Favorites",
+    "series_index": 1.0
+  },
+  {
+    "id": 5510,
+    "series": "Do it Til We Get it Right",
+    "series_index": 1.0
+  },
+  {
+    "id": 5512,
+    "series": "Remember This Cold",
+    "series_index": 37.0
+  },
+  {
+    "id": 5522,
+    "series": "out of the dust; into the dark",
+    "series_index": 4.0
+  },
+  {
+    "id": 5526,
+    "series": "Guitar and Video Games",
+    "series_index": 14.0
+  },
+  {
+    "id": 5529,
+    "series": "little beasts",
+    "series_index": 53.0
+  },
+  {
+    "id": 5531,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 81.0
+  },
+  {
+    "id": 5532,
+    "series": "little beasts",
+    "series_index": 50.0
+  },
+  {
+    "id": 5533,
+    "series": "out of the dust; into the dark",
+    "series_index": 2.0
+  },
+  {
+    "id": 5535,
+    "series": "princess Jay",
+    "series_index": 4.0
+  },
+  {
+    "id": 5546,
+    "series": "little beasts",
+    "series_index": 63.0
+  },
+  {
+    "id": 5551,
+    "series": "Multidimensional Intergalactic Road Trip",
+    "series_index": 2.0
+  },
+  {
+    "id": 5567,
+    "series": "into something rich and strange",
+    "series_index": 1.0
+  },
+  {
+    "id": 5571,
+    "series": "The One Where Loki and Steve Might Be Friends (sort of)",
+    "series_index": 3.0
+  },
+  {
+    "id": 5576,
+    "series": "little beasts",
+    "series_index": 58.0
+  },
+  {
+    "id": 5578,
+    "series": "little beasts",
+    "series_index": 49.0
+  },
+  {
+    "id": 5586,
+    "series": "Remember This Cold",
+    "series_index": 40.0
+  },
+  {
+    "id": 5587,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 85.0
+  },
+  {
+    "id": 5588,
+    "series": "little beasts",
+    "series_index": 24.0
+  },
+  {
+    "id": 5595,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 34.0
+  },
+  {
+    "id": 5597,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 87.0
+  },
+  {
+    "id": 5600,
+    "series": "little beasts",
+    "series_index": 54.0
+  },
+  {
+    "id": 5601,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 88.0
+  },
+  {
+    "id": 5602,
+    "series": "[to see you there]",
+    "series_index": 4.0
+  },
+  {
+    "id": 5603,
+    "series": "[to see you there]",
+    "series_index": 3.0
+  },
+  {
+    "id": 5605,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 90.0
+  },
+  {
+    "id": 5608,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 91.0
+  },
+  {
+    "id": 5614,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 92.0
+  },
+  {
+    "id": 5616,
+    "series": "mallverse",
+    "series_index": 6.0
+  },
+  {
+    "id": 5617,
+    "series": "mallverse",
+    "series_index": 3.0
+  },
+  {
+    "id": 5618,
+    "series": "mallverse",
+    "series_index": 4.0
+  },
+  {
+    "id": 5619,
+    "series": "mallverse",
+    "series_index": 2.0
+  },
+  {
+    "id": 5620,
+    "series": "mallverse",
+    "series_index": 5.0
+  },
+  {
+    "id": 5623,
+    "series": "not just good business",
+    "series_index": 1.0
+  },
+  {
+    "id": 5626,
+    "series": "mallverse",
+    "series_index": 7.0
+  },
+  {
+    "id": 5634,
+    "series": "Remember This Cold",
+    "series_index": 16.0
+  },
+  {
+    "id": 5635,
+    "series": "not just good business",
+    "series_index": 2.0
+  },
+  {
+    "id": 5640,
+    "series": "not just good business",
+    "series_index": 3.0
+  },
+  {
+    "id": 5643,
+    "series": "not just good business",
+    "series_index": 4.0
+  },
+  {
+    "id": 5645,
+    "series": "A Great and Gruesome Height",
+    "series_index": 1.0
+  },
+  {
+    "id": 5650,
+    "series": "little beasts",
+    "series_index": 61.0
+  },
+  {
+    "id": 5656,
+    "series": "[to see you there]",
+    "series_index": 25.0
+  },
+  {
+    "id": 5657,
+    "series": "little beasts",
+    "series_index": 60.0
+  },
+  {
+    "id": 5668,
+    "series": "Thor Works",
+    "series_index": 4.0
+  },
+  {
+    "id": 5671,
+    "series": "Glitter Is The Gold",
+    "series_index": 1.0
+  },
+  {
+    "id": 5674,
+    "series": "Infinite Coffee and Protection Detail",
+    "series_index": 5.0
+  },
+  {
+    "id": 5677,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 94.0
+  },
+  {
+    "id": 5679,
+    "series": "Remember This Cold",
+    "series_index": 30.0
+  },
+  {
+    "id": 5680,
+    "series": "little beasts",
+    "series_index": 31.0
+  },
+  {
+    "id": 5681,
+    "series": "little beasts",
+    "series_index": 15.0
+  },
+  {
+    "id": 5683,
+    "series": "little beasts",
+    "series_index": 67.0
+  },
+  {
+    "id": 5684,
+    "series": "little beasts",
+    "series_index": 62.0
+  },
+  {
+    "id": 5687,
+    "series": "Multidimensional Intergalactic Road Trip",
+    "series_index": 1.0
+  },
+  {
+    "id": 5689,
+    "series": "[to see you there]",
+    "series_index": 7.0
+  },
+  {
+    "id": 5691,
+    "series": "little beasts",
+    "series_index": 66.0
+  },
+  {
+    "id": 5692,
+    "series": "mallverse",
+    "series_index": 8.0
+  },
+  {
+    "id": 5693,
+    "series": "out of the dust; into the dark",
+    "series_index": 1.0
+  },
+  {
+    "id": 5696,
+    "series": "mallverse",
+    "series_index": 9.0
+  },
+  {
+    "id": 5697,
+    "series": "[to see you there]",
+    "series_index": 6.0
+  },
+  {
+    "id": 5698,
+    "series": "mallverse",
+    "series_index": 10.0
+  },
+  {
+    "id": 5699,
+    "series": "mallverse",
+    "series_index": 1.0
+  },
+  {
+    "id": 5700,
+    "series": "mallverse",
+    "series_index": 11.0
+  },
+  {
+    "id": 5701,
+    "series": "mallverse",
+    "series_index": 12.0
+  },
+  {
+    "id": 5702,
+    "series": "little beasts",
+    "series_index": 22.0
+  },
+  {
+    "id": 5703,
+    "series": "Mermaid Week",
+    "series_index": 1.0
+  },
+  {
+    "id": 5704,
+    "series": "mallverse",
+    "series_index": 13.0
+  },
+  {
+    "id": 5705,
+    "series": "Mermaid Week",
+    "series_index": 2.0
+  },
+  {
+    "id": 5709,
+    "series": "Mermaid Week",
+    "series_index": 3.0
+  },
+  {
+    "id": 5710,
+    "series": "little beasts",
+    "series_index": 29.0
+  },
+  {
+    "id": 5711,
+    "series": "mallverse",
+    "series_index": 14.0
+  },
+  {
+    "id": 5712,
+    "series": "Mermaid Week",
+    "series_index": 4.0
+  },
+  {
+    "id": 5714,
+    "series": "Author's Favorites",
+    "series_index": 4.0
+  },
+  {
+    "id": 5715,
+    "series": "Mermaid Week",
+    "series_index": 5.0
+  },
+  {
+    "id": 5717,
+    "series": "The More Loving One (Beyond Beyond Re-Animator)",
+    "series_index": 1.0
+  },
+  {
+    "id": 5718,
+    "series": "Mermaid Week",
+    "series_index": 6.0
+  },
+  {
+    "id": 5719,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 93.0
+  },
+  {
+    "id": 5720,
+    "series": "Mermaid Week",
+    "series_index": 7.0
+  },
+  {
+    "id": 5722,
+    "series": "little beasts",
+    "series_index": 28.0
+  },
+  {
+    "id": 5725,
+    "series": "Faerie Week",
+    "series_index": 1.0
+  },
+  {
+    "id": 5728,
+    "series": "Faerie Week",
+    "series_index": 2.0
+  },
+  {
+    "id": 5729,
+    "series": "Faerie Week",
+    "series_index": 3.0
+  },
+  {
+    "id": 5732,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 95.0
+  },
+  {
+    "id": 5735,
+    "series": "Faerie Week",
+    "series_index": 4.0
+  },
+  {
+    "id": 5736,
+    "series": "Faerie Week",
+    "series_index": 5.0
+  },
+  {
+    "id": 5738,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 96.0
+  },
+  {
+    "id": 5741,
+    "series": "mallverse",
+    "series_index": 15.0
+  },
+  {
+    "id": 5742,
+    "series": "Faerie Week",
+    "series_index": 6.0
+  },
+  {
+    "id": 5743,
+    "series": "Distant Shores and Voices",
+    "series_index": 1.0
+  },
+  {
+    "id": 5744,
+    "series": "Faerie Week",
+    "series_index": 7.0
+  },
+  {
+    "id": 5747,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 97.0
+  },
+  {
+    "id": 5749,
+    "series": "mallverse",
+    "series_index": 16.0
+  },
+  {
+    "id": 5751,
+    "series": "mallverse",
+    "series_index": 17.0
+  },
+  {
+    "id": 5752,
+    "series": "Curses Week",
+    "series_index": 1.0
+  },
+  {
+    "id": 5755,
+    "series": "Curses Week",
+    "series_index": 2.0
+  },
+  {
+    "id": 5756,
+    "series": "Curses Week",
+    "series_index": 3.0
+  },
+  {
+    "id": 5757,
+    "series": "Ain't No Grave",
+    "series_index": 1.0
+  },
+  {
+    "id": 5758,
+    "series": "The More Loving One (Beyond Beyond Re-Animator)",
+    "series_index": 2.0
+  },
+  {
+    "id": 5759,
+    "series": "The More Loving One (Beyond Beyond Re-Animator)",
+    "series_index": 3.0
+  },
+  {
+    "id": 5760,
+    "series": "The More Loving One (Beyond Beyond Re-Animator)",
+    "series_index": 4.0
+  },
+  {
+    "id": 5761,
+    "series": "Curses Week",
+    "series_index": 4.0
+  },
+  {
+    "id": 5762,
+    "series": "Curses Week",
+    "series_index": 5.0
+  },
+  {
+    "id": 5765,
+    "series": "Fast Talk Verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 5767,
+    "series": "Infinite Coffee and Protection Detail",
+    "series_index": 6.0
+  },
+  {
+    "id": 5769,
+    "series": "Curses Week",
+    "series_index": 6.0
+  },
+  {
+    "id": 5770,
+    "series": "Curses Week",
+    "series_index": 7.0
+  },
+  {
+    "id": 5771,
+    "series": "Death Week",
+    "series_index": 1.0
+  },
+  {
+    "id": 5772,
+    "series": "Death Week",
+    "series_index": 2.0
+  },
+  {
+    "id": 5774,
+    "series": "Distant Shores and Voices",
+    "series_index": 3.0
+  },
+  {
+    "id": 5777,
+    "series": "Ain't No Grave",
+    "series_index": 2.0
+  },
+  {
+    "id": 5779,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 98.0
+  },
+  {
+    "id": 5781,
+    "series": "Death Week",
+    "series_index": 3.0
+  },
+  {
+    "id": 5782,
+    "series": "Death Week",
+    "series_index": 4.0
+  },
+  {
+    "id": 5783,
+    "series": "Death Week",
+    "series_index": 5.0
+  },
+  {
+    "id": 5787,
+    "series": "Death Week",
+    "series_index": 6.0
+  },
+  {
+    "id": 5788,
+    "series": "Death Week",
+    "series_index": 7.0
+  },
+  {
+    "id": 5789,
+    "series": "Stucky fic",
+    "series_index": 4.0
+  },
+  {
+    "id": 5790,
+    "series": "Gulfport: A British Petroleum Fanfic",
+    "series_index": 2.0
+  },
+  {
+    "id": 5791,
+    "series": "mallverse",
+    "series_index": 18.0
+  },
+  {
+    "id": 5792,
+    "series": "Distant Shores and Voices",
+    "series_index": 4.0
+  },
+  {
+    "id": 5798,
+    "series": "Remember This Cold",
+    "series_index": 33.0
+  },
+  {
+    "id": 5799,
+    "series": "Author's Favourites",
+    "series_index": 7.0
+  },
+  {
+    "id": 5801,
+    "series": "bandom commentfics and drabbles",
+    "series_index": 2.0
+  },
+  {
+    "id": 5802,
+    "series": "Remember This Cold",
+    "series_index": 21.0
+  },
+  {
+    "id": 5803,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 15.0
+  },
+  {
+    "id": 5804,
+    "series": "nothing but the bones",
+    "series_index": 2.0
+  },
+  {
+    "id": 5805,
+    "series": "Distant Shores and Voices",
+    "series_index": 6.0
+  },
+  {
+    "id": 5808,
+    "series": "cooking competition au",
+    "series_index": 1.0
+  },
+  {
+    "id": 5809,
+    "series": "bandom commentfics and drabbles",
+    "series_index": 1.0
+  },
+  {
+    "id": 5815,
+    "series": "little beasts",
+    "series_index": 20.0
+  },
+  {
+    "id": 5817,
+    "series": "bandom commentfics and drabbles",
+    "series_index": 3.0
+  },
+  {
+    "id": 5820,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 31.0
+  },
+  {
+    "id": 5823,
+    "series": "bandom commentfics and drabbles",
+    "series_index": 4.0
+  },
+  {
+    "id": 5824,
+    "series": "not just good business",
+    "series_index": 6.0
+  },
+  {
+    "id": 5825,
+    "series": "In Which Tony Stark Builds Himself Some Friends (But His Family Was Assigned by Nick Fury)",
+    "series_index": 4.0
+  },
+  {
+    "id": 5826,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 99.0
+  },
+  {
+    "id": 5827,
+    "series": "I Was Kidnapped by Burly Qunari Pirates!",
+    "series_index": 1.0
+  },
+  {
+    "id": 5832,
+    "series": "Sins of Omission",
+    "series_index": 1.0
+  },
+  {
+    "id": 5839,
+    "series": "Remember This Cold",
+    "series_index": 77.0
+  },
+  {
+    "id": 5840,
+    "series": "The More Loving One (Beyond Beyond Re-Animator)",
+    "series_index": 5.0
+  },
+  {
+    "id": 5841,
+    "series": "Remember This Cold",
+    "series_index": 41.0
+  },
+  {
+    "id": 5843,
+    "series": "myth au",
+    "series_index": 2.0
+  },
+  {
+    "id": 5845,
+    "series": "myth au",
+    "series_index": 1.0
+  },
+  {
+    "id": 5847,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 101.0
+  },
+  {
+    "id": 5850,
+    "series": "Infinite Coffee and Protection Detail",
+    "series_index": 3.0
+  },
+  {
+    "id": 5852,
+    "series": "The More Loving One (Beyond Beyond Re-Animator)",
+    "series_index": 6.0
+  },
+  {
+    "id": 5856,
+    "series": "In Which Tony Stark Builds Himself Some Friends (But His Family Was Assigned by Nick Fury)",
+    "series_index": 5.0
+  },
+  {
+    "id": 5859,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 100.0
+  },
+  {
+    "id": 5860,
+    "series": "Skeletons",
+    "series_index": 1.0
+  },
+  {
+    "id": 5861,
+    "series": "myth au",
+    "series_index": 3.0
+  },
+  {
+    "id": 5868,
+    "series": "christmas '15",
+    "series_index": 1.0
+  },
+  {
+    "id": 5869,
+    "series": "not just good business",
+    "series_index": 7.0
+  },
+  {
+    "id": 5870,
+    "series": "Remember This Cold",
+    "series_index": 44.0
+  },
+  {
+    "id": 5873,
+    "series": "scenes from a reconciliation",
+    "series_index": 1.0
+  },
+  {
+    "id": 5875,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 41.0
+  },
+  {
+    "id": 5878,
+    "series": "Author's Favorites",
+    "series_index": 13.0
+  },
+  {
+    "id": 5881,
+    "series": "Easy With Daemons In",
+    "series_index": 1.0
+  },
+  {
+    "id": 5882,
+    "series": "Easy With Daemons In",
+    "series_index": 2.0
+  },
+  {
+    "id": 5883,
+    "series": "Easy With Daemons In",
+    "series_index": 4.0
+  },
+  {
+    "id": 5884,
+    "series": "Easy With Daemons In",
+    "series_index": 5.0
+  },
+  {
+    "id": 5885,
+    "series": "Easy With Daemons In",
+    "series_index": 6.0
+  },
+  {
+    "id": 5886,
+    "series": "Easy With Daemons In",
+    "series_index": 7.0
+  },
+  {
+    "id": 5887,
+    "series": "Easy With Daemons In",
+    "series_index": 8.0
+  },
+  {
+    "id": 5888,
+    "series": "Easy With Daemons In",
+    "series_index": 3.0
+  },
+  {
+    "id": 5896,
+    "series": "christmas '15",
+    "series_index": 2.0
+  },
+  {
+    "id": 5914,
+    "series": "Remember This Cold",
+    "series_index": 2.0
+  },
+  {
+    "id": 5919,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 103.0
+  },
+  {
+    "id": 5922,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 104.0
+  },
+  {
+    "id": 5932,
+    "series": "out of the dust; into the dark",
+    "series_index": 3.0
+  },
+  {
+    "id": 5935,
+    "series": "Distant Shores and Voices",
+    "series_index": 17.0
+  },
+  {
+    "id": 5938,
+    "series": "Children, Wake Up",
+    "series_index": 1.0
+  },
+  {
+    "id": 5951,
+    "series": "Distant Shores and Voices",
+    "series_index": 15.0
+  },
+  {
+    "id": 5956,
+    "series": "mallverse",
+    "series_index": 19.0
+  },
+  {
+    "id": 5958,
+    "series": "A6A4",
+    "series_index": 1.0
+  },
+  {
+    "id": 5960,
+    "series": "christmas '15",
+    "series_index": 3.0
+  },
+  {
+    "id": 5962,
+    "series": "Star Wars Works",
+    "series_index": 1.0
+  },
+  {
+    "id": 5963,
+    "series": "Star Wars Works",
+    "series_index": 2.0
+  },
+  {
+    "id": 5964,
+    "series": "mallverse",
+    "series_index": 20.0
+  },
+  {
+    "id": 5966,
+    "series": "After The Fall",
+    "series_index": 2.0
+  },
+  {
+    "id": 5969,
+    "series": "Distant Shores and Voices",
+    "series_index": 2.0
+  },
+  {
+    "id": 5970,
+    "series": "Children, Wake Up",
+    "series_index": 2.0
+  },
+  {
+    "id": 5971,
+    "series": "cooking competition au",
+    "series_index": 2.0
+  },
+  {
+    "id": 5979,
+    "series": "Author's Favourites",
+    "series_index": 10.0
+  },
+  {
+    "id": 5982,
+    "series": "Star Wars Works",
+    "series_index": 7.0
+  },
+  {
+    "id": 5986,
+    "series": "out of the dust; into the dark",
+    "series_index": 5.0
+  },
+  {
+    "id": 5987,
+    "series": "Remember This Cold",
+    "series_index": 45.0
+  },
+  {
+    "id": 5994,
+    "series": "princess Jay",
+    "series_index": 3.0
+  },
+  {
+    "id": 5996,
+    "series": "Star Wars Works",
+    "series_index": 6.0
+  },
+  {
+    "id": 5997,
+    "series": "princess Jay",
+    "series_index": 2.0
+  },
+  {
+    "id": 5998,
+    "series": "Star Wars Works",
+    "series_index": 5.0
+  },
+  {
+    "id": 5999,
+    "series": "Star Wars Works",
+    "series_index": 17.0
+  },
+  {
+    "id": 6011,
+    "series": "[to see you there]",
+    "series_index": 13.0
+  },
+  {
+    "id": 6021,
+    "series": "Star Wars Works",
+    "series_index": 16.0
+  },
+  {
+    "id": 6024,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 1.0
+  },
+  {
+    "id": 6025,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 2.0
+  },
+  {
+    "id": 6026,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 3.0
+  },
+  {
+    "id": 6027,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 4.0
+  },
+  {
+    "id": 6028,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 5.0
+  },
+  {
+    "id": 6029,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 6.0
+  },
+  {
+    "id": 6032,
+    "series": "Remember This Cold",
+    "series_index": 3.0
+  },
+  {
+    "id": 6033,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 86.0
+  },
+  {
+    "id": 6034,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 108.0
+  },
+  {
+    "id": 6036,
+    "series": "Thor Works",
+    "series_index": 6.0
+  },
+  {
+    "id": 6037,
+    "series": "Thor Works",
+    "series_index": 5.0
+  },
+  {
+    "id": 6038,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 107.0
+  },
+  {
+    "id": 6041,
+    "series": "Children, Wake Up",
+    "series_index": 3.0
+  },
+  {
+    "id": 6042,
+    "series": "Star Wars Works",
+    "series_index": 15.0
+  },
+  {
+    "id": 6047,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 89.0
+  },
+  {
+    "id": 6053,
+    "series": "Distant Shores and Voices",
+    "series_index": 8.0
+  },
+  {
+    "id": 6054,
+    "series": "One Different Night: TFA Modern AU",
+    "series_index": 1.0
+  },
+  {
+    "id": 6055,
+    "series": "Star Wars Works",
+    "series_index": 14.0
+  },
+  {
+    "id": 6066,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 7.0
+  },
+  {
+    "id": 6086,
+    "series": "little beasts",
+    "series_index": 70.0
+  },
+  {
+    "id": 6087,
+    "series": "little beasts",
+    "series_index": 69.0
+  },
+  {
+    "id": 6088,
+    "series": "little beasts",
+    "series_index": 8.0
+  },
+  {
+    "id": 6112,
+    "series": "Remember This Cold",
+    "series_index": 42.0
+  },
+  {
+    "id": 6121,
+    "series": "Star Wars Works",
+    "series_index": 13.0
+  },
+  {
+    "id": 6124,
+    "series": "little beasts",
+    "series_index": 43.0
+  },
+  {
+    "id": 6125,
+    "series": "little beasts",
+    "series_index": 30.0
+  },
+  {
+    "id": 6126,
+    "series": "Remember This Cold",
+    "series_index": 8.0
+  },
+  {
+    "id": 6128,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 113.0
+  },
+  {
+    "id": 6131,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 56.0
+  },
+  {
+    "id": 6134,
+    "series": "Ain't No Grave",
+    "series_index": 3.0
+  },
+  {
+    "id": 6138,
+    "series": "little beasts",
+    "series_index": 23.0
+  },
+  {
+    "id": 6139,
+    "series": "In Which Tony Stark Builds Himself Some Friends (But His Family Was Assigned by Nick Fury)",
+    "series_index": 6.0
+  },
+  {
+    "id": 6140,
+    "series": "Flipping Switches",
+    "series_index": 1.0
+  },
+  {
+    "id": 6141,
+    "series": "Remember This Cold",
+    "series_index": 43.0
+  },
+  {
+    "id": 6145,
+    "series": "Mirrorism",
+    "series_index": 2.0
+  },
+  {
+    "id": 6150,
+    "series": "Remember This Cold",
+    "series_index": 35.0
+  },
+  {
+    "id": 6154,
+    "series": "Moriarty TRIES to ruin everything.",
+    "series_index": 1.0
+  },
+  {
+    "id": 6155,
+    "series": "Moriarty TRIES to ruin everything.",
+    "series_index": 2.0
+  },
+  {
+    "id": 6156,
+    "series": "out of the dust; into the dark",
+    "series_index": 6.0
+  },
+  {
+    "id": 6162,
+    "series": "mallverse",
+    "series_index": 21.0
+  },
+  {
+    "id": 6163,
+    "series": "Howling Commandos",
+    "series_index": 4.0
+  },
+  {
+    "id": 6172,
+    "series": "not just good business",
+    "series_index": 5.0
+  },
+  {
+    "id": 6174,
+    "series": "mallverse",
+    "series_index": 22.0
+  },
+  {
+    "id": 6175,
+    "series": "little beasts",
+    "series_index": 44.0
+  },
+  {
+    "id": 6182,
+    "series": "Star Wars Works",
+    "series_index": 12.0
+  },
+  {
+    "id": 6184,
+    "series": "Author's Favorites",
+    "series_index": 5.0
+  },
+  {
+    "id": 6192,
+    "series": "mallverse",
+    "series_index": 23.0
+  },
+  {
+    "id": 6194,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 8.0
+  },
+  {
+    "id": 6195,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 1.0
+  },
+  {
+    "id": 6197,
+    "series": "Gehenna",
+    "series_index": 1.0
+  },
+  {
+    "id": 6201,
+    "series": "mallverse",
+    "series_index": 24.0
+  },
+  {
+    "id": 6210,
+    "series": "Alt-country",
+    "series_index": 1.0
+  },
+  {
+    "id": 6211,
+    "series": "Alt-country",
+    "series_index": 2.0
+  },
+  {
+    "id": 6212,
+    "series": "Alt-country",
+    "series_index": 3.0
+  },
+  {
+    "id": 6217,
+    "series": "Of Water and Roses",
+    "series_index": 1.0
+  },
+  {
+    "id": 6224,
+    "series": "Remember This Cold",
+    "series_index": 50.0
+  },
+  {
+    "id": 6226,
+    "series": "Cousin Harry",
+    "series_index": 1.0
+  },
+  {
+    "id": 6229,
+    "series": "Remember This Cold",
+    "series_index": 53.0
+  },
+  {
+    "id": 6231,
+    "series": "Commander Eliza Shepard",
+    "series_index": 9.0
+  },
+  {
+    "id": 6235,
+    "series": "To Die as Lovers May",
+    "series_index": 1.0
+  },
+  {
+    "id": 6236,
+    "series": "Thor Works",
+    "series_index": 3.0
+  },
+  {
+    "id": 6239,
+    "series": "everyone's got someplace they want to be let in",
+    "series_index": 1.0
+  },
+  {
+    "id": 6242,
+    "series": "Remember This Cold",
+    "series_index": 38.0
+  },
+  {
+    "id": 6243,
+    "series": "Distant Shores and Voices",
+    "series_index": 18.0
+  },
+  {
+    "id": 6244,
+    "series": "mallverse",
+    "series_index": 25.0
+  },
+  {
+    "id": 6246,
+    "series": "[to see you there]",
+    "series_index": 19.0
+  },
+  {
+    "id": 6247,
+    "series": "everyone's got someplace they want to be let in",
+    "series_index": 2.0
+  },
+  {
+    "id": 6250,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 47.0
+  },
+  {
+    "id": 6253,
+    "series": "Star Wars Works",
+    "series_index": 3.0
+  },
+  {
+    "id": 6257,
+    "series": "To Die as Lovers May",
+    "series_index": 2.0
+  },
+  {
+    "id": 6258,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 114.0
+  },
+  {
+    "id": 6260,
+    "series": "BuckRogers vs. the Internet",
+    "series_index": 1.0
+  },
+  {
+    "id": 6262,
+    "series": "Tithe",
+    "series_index": 1.0
+  },
+  {
+    "id": 6264,
+    "series": "between the elevated road and the water",
+    "series_index": 1.0
+  },
+  {
+    "id": 6265,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 115.0
+  },
+  {
+    "id": 6268,
+    "series": "Remember This Cold",
+    "series_index": 48.0
+  },
+  {
+    "id": 6269,
+    "series": "Sorrowful and Immaculate Hearts",
+    "series_index": 9.0
+  },
+  {
+    "id": 6272,
+    "series": "between the elevated road and the water",
+    "series_index": 2.0
+  },
+  {
+    "id": 6274,
+    "series": "Distant Shores and Voices",
+    "series_index": 10.0
+  },
+  {
+    "id": 6285,
+    "series": "growing stronger",
+    "series_index": 1.0
+  },
+  {
+    "id": 6286,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 116.0
+  },
+  {
+    "id": 6287,
+    "series": "Glitter Is The Gold",
+    "series_index": 2.0
+  },
+  {
+    "id": 6290,
+    "series": "Remember This Cold",
+    "series_index": 5.0
+  },
+  {
+    "id": 6298,
+    "series": "Remember This Cold",
+    "series_index": 47.0
+  },
+  {
+    "id": 6303,
+    "series": "mallverse",
+    "series_index": 26.0
+  },
+  {
+    "id": 6310,
+    "series": "Dancers/Letters",
+    "series_index": 2.0
+  },
+  {
+    "id": 6315,
+    "series": "He Who Must Be Kept",
+    "series_index": 2.0
+  },
+  {
+    "id": 6321,
+    "series": "Remember This Cold",
+    "series_index": 9.0
+  },
+  {
+    "id": 6324,
+    "series": "little beasts",
+    "series_index": 73.0
+  },
+  {
+    "id": 6326,
+    "series": "mallverse",
+    "series_index": 27.0
+  },
+  {
+    "id": 6330,
+    "series": "mallverse",
+    "series_index": 28.0
+  },
+  {
+    "id": 6332,
+    "series": "[to see you there]",
+    "series_index": 29.0
+  },
+  {
+    "id": 6333,
+    "series": "In Our City",
+    "series_index": 1.0
+  },
+  {
+    "id": 6342,
+    "series": "mallverse",
+    "series_index": 29.0
+  },
+  {
+    "id": 6348,
+    "series": "mallverse",
+    "series_index": 30.0
+  },
+  {
+    "id": 6353,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 9.0
+  },
+  {
+    "id": 6358,
+    "series": "Character",
+    "series_index": 1.0
+  },
+  {
+    "id": 6360,
+    "series": "Character",
+    "series_index": 2.0
+  },
+  {
+    "id": 6361,
+    "series": "Character",
+    "series_index": 3.0
+  },
+  {
+    "id": 6362,
+    "series": "mallverse",
+    "series_index": 31.0
+  },
+  {
+    "id": 6363,
+    "series": "mallverse",
+    "series_index": 32.0
+  },
+  {
+    "id": 6366,
+    "series": "In Our City",
+    "series_index": 2.0
+  },
+  {
+    "id": 6371,
+    "series": "mallverse",
+    "series_index": 33.0
+  },
+  {
+    "id": 6372,
+    "series": "recursive reciprocity",
+    "series_index": 1.0
+  },
+  {
+    "id": 6373,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 10.0
+  },
+  {
+    "id": 6375,
+    "series": "tumblr drabbles",
+    "series_index": 1.0
+  },
+  {
+    "id": 6376,
+    "series": "tumblr drabbles",
+    "series_index": 2.0
+  },
+  {
+    "id": 6377,
+    "series": "tumblr drabbles",
+    "series_index": 3.0
+  },
+  {
+    "id": 6378,
+    "series": "tumblr drabbles",
+    "series_index": 4.0
+  },
+  {
+    "id": 6379,
+    "series": "tumblr drabbles",
+    "series_index": 5.0
+  },
+  {
+    "id": 6380,
+    "series": "tumblr drabbles",
+    "series_index": 6.0
+  },
+  {
+    "id": 6381,
+    "series": "tumblr drabbles",
+    "series_index": 7.0
+  },
+  {
+    "id": 6382,
+    "series": "tumblr drabbles",
+    "series_index": 8.0
+  },
+  {
+    "id": 6383,
+    "series": "tumblr drabbles",
+    "series_index": 9.0
+  },
+  {
+    "id": 6384,
+    "series": "tumblr drabbles",
+    "series_index": 12.0
+  },
+  {
+    "id": 6385,
+    "series": "tumblr drabbles",
+    "series_index": 13.0
+  },
+  {
+    "id": 6386,
+    "series": "tumblr drabbles",
+    "series_index": 14.0
+  },
+  {
+    "id": 6387,
+    "series": "tumblr drabbles",
+    "series_index": 15.0
+  },
+  {
+    "id": 6388,
+    "series": "tumblr drabbles",
+    "series_index": 16.0
+  },
+  {
+    "id": 6389,
+    "series": "tumblr drabbles",
+    "series_index": 17.0
+  },
+  {
+    "id": 6393,
+    "series": "Star Wars Works",
+    "series_index": 11.0
+  },
+  {
+    "id": 6398,
+    "series": "Remember This Cold",
+    "series_index": 7.0
+  },
+  {
+    "id": 6399,
+    "series": "He Who Must Be Kept",
+    "series_index": 1.0
+  },
+  {
+    "id": 6408,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 11.0
+  },
+  {
+    "id": 6410,
+    "series": "To Die as Lovers May",
+    "series_index": 3.0
+  },
+  {
+    "id": 6411,
+    "series": "Remember This Cold",
+    "series_index": 52.0
+  },
+  {
+    "id": 6414,
+    "series": "Gehenna",
+    "series_index": 2.0
+  },
+  {
+    "id": 6415,
+    "series": "ceasefire",
+    "series_index": 1.0
+  },
+  {
+    "id": 6417,
+    "series": "Gehenna",
+    "series_index": 5.0
+  },
+  {
+    "id": 6420,
+    "series": "little beasts",
+    "series_index": 9.0
+  },
+  {
+    "id": 6422,
+    "series": "To Die as Lovers May",
+    "series_index": 4.0
+  },
+  {
+    "id": 6423,
+    "series": "somewhere under the rainbow",
+    "series_index": 1.0
+  },
+  {
+    "id": 6424,
+    "series": "Remember This Cold",
+    "series_index": 51.0
+  },
+  {
+    "id": 6428,
+    "series": "Author's Favorites",
+    "series_index": 3.0
+  },
+  {
+    "id": 6430,
+    "series": "Tapestries",
+    "series_index": 1.0
+  },
+  {
+    "id": 6431,
+    "series": "recursive reciprocity",
+    "series_index": 2.0
+  },
+  {
+    "id": 6432,
+    "series": "mallverse",
+    "series_index": 34.0
+  },
+  {
+    "id": 6433,
+    "series": "To Die as Lovers May",
+    "series_index": 5.0
+  },
+  {
+    "id": 6440,
+    "series": "little beasts",
+    "series_index": 3.0
+  },
+  {
+    "id": 6441,
+    "series": "little beasts",
+    "series_index": 4.0
+  },
+  {
+    "id": 6443,
+    "series": "little beasts",
+    "series_index": 77.0
+  },
+  {
+    "id": 6446,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 117.0
+  },
+  {
+    "id": 6447,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 118.0
+  },
+  {
+    "id": 6448,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 119.0
+  },
+  {
+    "id": 6449,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 120.0
+  },
+  {
+    "id": 6450,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 122.0
+  },
+  {
+    "id": 6451,
+    "series": "mallverse",
+    "series_index": 35.0
+  },
+  {
+    "id": 6452,
+    "series": "Remember This Cold",
+    "series_index": 36.0
+  },
+  {
+    "id": 6457,
+    "series": "mallverse",
+    "series_index": 36.0
+  },
+  {
+    "id": 6458,
+    "series": "To Die as Lovers May",
+    "series_index": 6.0
+  },
+  {
+    "id": 6459,
+    "series": "mallverse",
+    "series_index": 37.0
+  },
+  {
+    "id": 6461,
+    "series": "boarding school au",
+    "series_index": 2.0
+  },
+  {
+    "id": 6462,
+    "series": "little beasts",
+    "series_index": 5.0
+  },
+  {
+    "id": 6463,
+    "series": "little beasts",
+    "series_index": 6.0
+  },
+  {
+    "id": 6464,
+    "series": "little beasts",
+    "series_index": 2.0
+  },
+  {
+    "id": 6467,
+    "series": "boarding school au",
+    "series_index": 3.0
+  },
+  {
+    "id": 6473,
+    "series": "little beasts",
+    "series_index": 79.0
+  },
+  {
+    "id": 6475,
+    "series": "ceasefire",
+    "series_index": 2.0
+  },
+  {
+    "id": 6482,
+    "series": "boarding school au",
+    "series_index": 1.0
+  },
+  {
+    "id": 6483,
+    "series": "mallverse",
+    "series_index": 38.0
+  },
+  {
+    "id": 6486,
+    "series": "mallverse",
+    "series_index": 39.0
+  },
+  {
+    "id": 6491,
+    "series": "mallverse",
+    "series_index": 40.0
+  },
+  {
+    "id": 6494,
+    "series": "mallverse",
+    "series_index": 41.0
+  },
+  {
+    "id": 6495,
+    "series": "bandom commentfics and drabbles",
+    "series_index": 5.0
+  },
+  {
+    "id": 6496,
+    "series": "ceasefire",
+    "series_index": 4.0
+  },
+  {
+    "id": 6500,
+    "series": "mallverse",
+    "series_index": 42.0
+  },
+  {
+    "id": 6503,
+    "series": "mallverse",
+    "series_index": 43.0
+  },
+  {
+    "id": 6504,
+    "series": "The Aoba Johsai Gangbang Show",
+    "series_index": 1.0
+  },
+  {
+    "id": 6507,
+    "series": "i feel god in this kentucky tonight",
+    "series_index": 2.0
+  },
+  {
+    "id": 6511,
+    "series": "Today, your barista 'verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 6512,
+    "series": "Commander Eliza Shepard",
+    "series_index": 6.0
+  },
+  {
+    "id": 6513,
+    "series": "Today, your barista 'verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 6516,
+    "series": "Commander Eliza Shepard",
+    "series_index": 8.0
+  },
+  {
+    "id": 6517,
+    "series": "we will be dangerous acquaintances with a history",
+    "series_index": 1.0
+  },
+  {
+    "id": 6518,
+    "series": "somewhere under the rainbow",
+    "series_index": 2.0
+  },
+  {
+    "id": 6519,
+    "series": "Remember This Cold",
+    "series_index": 10.0
+  },
+  {
+    "id": 6523,
+    "series": "mallverse",
+    "series_index": 44.0
+  },
+  {
+    "id": 6524,
+    "series": "little beasts",
+    "series_index": 81.0
+  },
+  {
+    "id": 6525,
+    "series": "mallverse",
+    "series_index": 45.0
+  },
+  {
+    "id": 6526,
+    "series": "mallverse",
+    "series_index": 46.0
+  },
+  {
+    "id": 6527,
+    "series": "Remember This Cold",
+    "series_index": 14.0
+  },
+  {
+    "id": 6528,
+    "series": "To Die as Lovers May",
+    "series_index": 7.0
+  },
+  {
+    "id": 6529,
+    "series": "mallverse",
+    "series_index": 47.0
+  },
+  {
+    "id": 6533,
+    "series": "ceasefire",
+    "series_index": 3.0
+  },
+  {
+    "id": 6536,
+    "series": "princess Jay",
+    "series_index": 1.0
+  },
+  {
+    "id": 6539,
+    "series": "mallverse",
+    "series_index": 48.0
+  },
+  {
+    "id": 6551,
+    "series": "Star Wars Works",
+    "series_index": 10.0
+  },
+  {
+    "id": 6552,
+    "series": "Star Wars Works",
+    "series_index": 9.0
+  },
+  {
+    "id": 6556,
+    "series": "Ghosts of All My Lovely Sins",
+    "series_index": 2.0
+  },
+  {
+    "id": 6557,
+    "series": "Magazineverse",
+    "series_index": 1.0
+  },
+  {
+    "id": 6559,
+    "series": "mallverse",
+    "series_index": 49.0
+  },
+  {
+    "id": 6560,
+    "series": "the greatest",
+    "series_index": 1.0
+  },
+  {
+    "id": 6562,
+    "series": "mallverse",
+    "series_index": 50.0
+  },
+  {
+    "id": 6563,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 102.0
+  },
+  {
+    "id": 6574,
+    "series": "To Die as Lovers May",
+    "series_index": 8.0
+  },
+  {
+    "id": 6575,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 123.0
+  },
+  {
+    "id": 6585,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 112.0
+  },
+  {
+    "id": 6586,
+    "series": "Today, your barista 'verse",
+    "series_index": 3.0
+  },
+  {
+    "id": 6587,
+    "series": "little beasts",
+    "series_index": 83.0
+  },
+  {
+    "id": 6589,
+    "series": "little beasts",
+    "series_index": 84.0
+  },
+  {
+    "id": 6590,
+    "series": "mallverse",
+    "series_index": 51.0
+  },
+  {
+    "id": 6591,
+    "series": "mallverse",
+    "series_index": 52.0
+  },
+  {
+    "id": 6592,
+    "series": "little beasts",
+    "series_index": 85.0
+  },
+  {
+    "id": 6593,
+    "series": "Remember This Cold",
+    "series_index": 13.0
+  },
+  {
+    "id": 6596,
+    "series": "The Aoba Johsai Gangbang Show",
+    "series_index": 2.0
+  },
+  {
+    "id": 6599,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 125.0
+  },
+  {
+    "id": 6600,
+    "series": "mallverse",
+    "series_index": 53.0
+  },
+  {
+    "id": 6603,
+    "series": "your blue-eyed boys",
+    "series_index": 6.0
+  },
+  {
+    "id": 6604,
+    "series": "(even if i could) make a deal with god [your blue-eyed boys related short-fic]",
+    "series_index": 2.0
+  },
+  {
+    "id": 6606,
+    "series": "Remember This Cold",
+    "series_index": 31.0
+  },
+  {
+    "id": 6613,
+    "series": "the greatest",
+    "series_index": 2.0
+  },
+  {
+    "id": 6623,
+    "series": "Grim Tales",
+    "series_index": 1.0
+  },
+  {
+    "id": 6625,
+    "series": "Commander Eliza Shepard",
+    "series_index": 10.0
+  },
+  {
+    "id": 6627,
+    "series": "somewhere under the rainbow",
+    "series_index": 3.0
+  },
+  {
+    "id": 6633,
+    "series": "Notes on Thedas",
+    "series_index": 1.0
+  },
+  {
+    "id": 6634,
+    "series": "Alt-country",
+    "series_index": 1.0
+  },
+  {
+    "id": 6635,
+    "series": "Alt-country",
+    "series_index": 2.0
+  },
+  {
+    "id": 6637,
+    "series": "Alt-country",
+    "series_index": 3.0
+  },
+  {
+    "id": 6638,
+    "series": "mallverse",
+    "series_index": 54.0
+  },
+  {
+    "id": 6639,
+    "series": "Remember This Cold",
+    "series_index": 54.0
+  },
+  {
+    "id": 6652,
+    "series": "Remember This Cold",
+    "series_index": 56.0
+  },
+  {
+    "id": 6653,
+    "series": "From Out the Ocean Risen",
+    "series_index": 1.0
+  },
+  {
+    "id": 6656,
+    "series": "white, grey, and black",
+    "series_index": 1.0
+  },
+  {
+    "id": 6657,
+    "series": "Tails of Zabimaru [Podfic]",
+    "series_index": 1.0
+  },
+  {
+    "id": 6659,
+    "series": "Tails of Zabimaru [Podfic]",
+    "series_index": 2.0
+  },
+  {
+    "id": 6665,
+    "series": "bandom commentfics and drabbles",
+    "series_index": 6.0
+  },
+  {
+    "id": 6670,
+    "series": "white, grey, and black",
+    "series_index": 2.0
+  },
+  {
+    "id": 6671,
+    "series": "To Die as Lovers May",
+    "series_index": 9.0
+  },
+  {
+    "id": 6672,
+    "series": "[to see you there]",
+    "series_index": 9.0
+  },
+  {
+    "id": 6673,
+    "series": "the sun from shining",
+    "series_index": 1.0
+  },
+  {
+    "id": 6675,
+    "series": "mallverse",
+    "series_index": 55.0
+  },
+  {
+    "id": 6676,
+    "series": "Signature Blend (VC Coffee Shop AU)",
+    "series_index": 1.0
+  },
+  {
+    "id": 6681,
+    "series": "Star Wars Works",
+    "series_index": 8.0
+  },
+  {
+    "id": 6683,
+    "series": "mallverse",
+    "series_index": 56.0
+  },
+  {
+    "id": 6684,
+    "series": "Gehenna",
+    "series_index": 3.0
+  },
+  {
+    "id": 6685,
+    "series": "PWP: Pie Without Plot",
+    "series_index": 1.0
+  },
+  {
+    "id": 6693,
+    "series": "Ghosts of All My Lovely Sins",
+    "series_index": 1.0
+  },
+  {
+    "id": 6695,
+    "series": "I Was Kidnapped by Burly Qunari Pirates!",
+    "series_index": 2.0
+  },
+  {
+    "id": 6696,
+    "series": "sharp Evening stars and bright Morning flame",
+    "series_index": 8.0
+  },
+  {
+    "id": 6698,
+    "series": "the long way down",
+    "series_index": 1.0
+  },
+  {
+    "id": 6700,
+    "series": "People Are Hard",
+    "series_index": 1.0
+  },
+  {
+    "id": 6701,
+    "series": "After the War",
+    "series_index": 1.0
+  },
+  {
+    "id": 6706,
+    "series": "After the War",
+    "series_index": 2.0
+  },
+  {
+    "id": 6711,
+    "series": "Remember This Cold",
+    "series_index": 55.0
+  },
+  {
+    "id": 6723,
+    "series": "Remember This Cold",
+    "series_index": 4.0
+  },
+  {
+    "id": 6724,
+    "series": "From Out the Ocean Risen",
+    "series_index": 2.0
+  },
+  {
+    "id": 6726,
+    "series": "Author's Favorites",
+    "series_index": 10.0
+  },
+  {
+    "id": 6729,
+    "series": "all that glitters is not gold",
+    "series_index": 1.0
+  },
+  {
+    "id": 6732,
+    "series": "[to see you there]",
+    "series_index": 10.0
+  },
+  {
+    "id": 6735,
+    "series": "The Usher",
+    "series_index": 1.0
+  },
+  {
+    "id": 6743,
+    "series": "drabbles",
+    "series_index": 1.0
+  },
+  {
+    "id": 6749,
+    "series": "Divergence",
+    "series_index": 2.0
+  },
+  {
+    "id": 6753,
+    "series": "The Usher",
+    "series_index": 2.0
+  },
+  {
+    "id": 6754,
+    "series": "The Usher",
+    "series_index": 3.0
+  },
+  {
+    "id": 6758,
+    "series": "Ghosts of All My Lovely Sins",
+    "series_index": 3.0
+  },
+  {
+    "id": 6759,
+    "series": "Sam and Loki Are Roommates",
+    "series_index": 12.0
+  },
+  {
+    "id": 6761,
+    "series": "The Usher",
+    "series_index": 4.0
+  },
+  {
+    "id": 6763,
+    "series": "The Usher",
+    "series_index": 5.0
+  },
+  {
+    "id": 6766,
+    "series": "all that glitters is not gold",
+    "series_index": 2.0
+  },
+  {
+    "id": 6767,
+    "series": "Signature Blend (VC Coffee Shop AU)",
+    "series_index": 2.0
+  },
+  {
+    "id": 6771,
+    "series": "The Usher",
+    "series_index": 6.0
+  },
+  {
+    "id": 6776,
+    "series": "The Way We Know Sorrow",
+    "series_index": 1.0
+  },
+  {
+    "id": 6778,
+    "series": "People Are Hard",
+    "series_index": 2.0
+  },
+  {
+    "id": 6779,
+    "series": "Grim Tales",
+    "series_index": 2.0
+  },
+  {
+    "id": 6781,
+    "series": "Remember This Cold",
+    "series_index": 57.0
+  },
+  {
+    "id": 6782,
+    "series": "Remember This Cold",
+    "series_index": 15.0
+  },
+  {
+    "id": 6785,
+    "series": "Voltron RarePair Week 2017",
+    "series_index": 1.0
+  },
+  {
+    "id": 6788,
+    "series": "Voltron RarePair Week 2017",
+    "series_index": 2.0
+  },
+  {
+    "id": 6790,
+    "series": "cliche",
+    "series_index": 1.0
+  },
+  {
+    "id": 6792,
+    "series": "Take The Plan, Spin It Sideways",
+    "series_index": 1.0
+  },
+  {
+    "id": 6795,
+    "series": "To Die as Lovers May",
+    "series_index": 10.0
+  },
+  {
+    "id": 6796,
+    "series": "Voltron RarePair Week 2017",
+    "series_index": 3.0
+  },
+  {
+    "id": 6800,
+    "series": "The Usher",
+    "series_index": 7.0
+  },
+  {
+    "id": 6840,
+    "series": "Kinkmeme Fills",
+    "series_index": 2.0
+  },
+  {
+    "id": 6841,
+    "series": "See all this and more for just ten dollars a month!",
+    "series_index": 1.0
+  },
+  {
+    "id": 6843,
+    "series": "Zhaoxie week 2021",
+    "series_index": 1.0
+  },
+  {
+    "id": 6844,
+    "series": "Misalignment",
+    "series_index": 4.0
+  },
+  {
+    "id": 6847,
+    "series": "See all this and more for just ten dollars a month!",
+    "series_index": 4.0
+  },
+  {
+    "id": 6852,
+    "series": "like the holes of your heart",
+    "series_index": 3.0
+  },
+  {
+    "id": 6854,
+    "series": "light it up and let it burn",
+    "series_index": 5.0
+  },
+  {
+    "id": 6857,
+    "series": "Zhaoxie week 2021",
+    "series_index": 3.0
+  },
+  {
+    "id": 6859,
+    "series": "Tianchuang Era Zhou Zishu One-shots",
+    "series_index": 9.0
+  },
+  {
+    "id": 6862,
+    "series": "our love is small yet shining",
+    "series_index": 7.0
+  },
+  {
+    "id": 6863,
+    "series": "a comet pulled from orbit",
+    "series_index": 3.0
+  },
+  {
+    "id": 6866,
+    "series": "Zhaoxie week 2021",
+    "series_index": 2.0
+  },
+  {
+    "id": 6877,
+    "series": "involved metaphors",
+    "series_index": 2.0
+  },
+  {
+    "id": 6884,
+    "series": "Stop the World",
+    "series_index": 1.0
+  },
+  {
+    "id": 6887,
+    "series": "Zhaoxie week 2021",
+    "series_index": 4.0
+  },
+  {
+    "id": 6890,
+    "series": "the hand of the god-child",
+    "series_index": 2.0
+  },
+  {
+    "id": 6893,
+    "series": "Baby JGY",
+    "series_index": 2.0
+  },
+  {
+    "id": 6895,
+    "series": "fallen star, igneous rock",
+    "series_index": 1.0
+  },
+  {
+    "id": 6896,
+    "series": "pillows",
+    "series_index": 2.0
+  },
+  {
+    "id": 6897,
+    "series": "pillows",
+    "series_index": 1.0
+  },
+  {
+    "id": 6898,
+    "series": "pillows",
+    "series_index": 3.0
+  },
+  {
+    "id": 6899,
+    "series": "pillows",
+    "series_index": 4.0
+  },
+  {
+    "id": 6903,
+    "series": "The Amazing Adventures Of Jiang Xiaolian And Family",
+    "series_index": 3.0
+  },
+  {
+    "id": 6912,
+    "series": "JTWYA-verse",
+    "series_index": 10.0
+  },
+  {
+    "id": 6916,
+    "series": "the places Nobody knows",
+    "series_index": 4.0
+  },
+  {
+    "id": 6918,
+    "series": "in search of the moon (sms time travel 'verse)",
+    "series_index": 2.0
+  },
+  {
+    "id": 6925,
+    "series": "See all this and more for just ten dollars a month!",
+    "series_index": 3.0
+  },
+  {
+    "id": 6936,
+    "series": "borderlines",
+    "series_index": 2.0
+  },
+  {
+    "id": 6938,
+    "series": "of a kind",
+    "series_index": 2.0
+  },
+  {
+    "id": 6940,
+    "series": "involved metaphors",
+    "series_index": 7.0
+  },
+  {
+    "id": 6941,
+    "series": "Kinkmeme Fills",
+    "series_index": 11.0
+  },
+  {
+    "id": 6943,
+    "series": "Snake-Fight Crossovers",
+    "series_index": 3.0
+  },
+  {
+    "id": 6952,
+    "series": "Gender Swap, Three Styles",
+    "series_index": 1.0
+  },
+  {
+    "id": 6979,
+    "series": "some things stick",
+    "series_index": 4.0
+  },
+  {
+    "id": 6995,
+    "series": "fridge deer",
+    "series_index": 3.0
+  },
+  {
+    "id": 6999,
+    "series": "Snake-Fight Crossovers",
+    "series_index": 4.0
+  },
+  {
+    "id": 7041,
+    "series": "involved metaphors",
+    "series_index": 6.0
+  },
+  {
+    "id": 7054,
+    "series": "i don't pity your anger (just give me your heart)",
+    "series_index": 1.0
+  },
+  {
+    "id": 7056,
+    "series": "frayed",
+    "series_index": 7.0
+  },
+  {
+    "id": 7064,
+    "series": "Twelve Moons and a Fortnight Verse",
+    "series_index": 2.0
+  },
+  {
+    "id": 7065,
+    "series": "isn't it pretty to think",
+    "series_index": 2.0
+  },
+  {
+    "id": 7068,
+    "series": "mdzs daemon au",
+    "series_index": 2.0
+  },
+  {
+    "id": 7069,
+    "series": "Working Title: Everyone Lives (With Knives)",
+    "series_index": 2.0
+  },
+  {
+    "id": 7072,
+    "series": "if living can be this",
+    "series_index": 9.0
+  },
+  {
+    "id": 7080,
+    "series": "'uninvited' au verse fics",
+    "series_index": 1.0
+  },
+  {
+    "id": 7092,
+    "series": "Kinktober 2021",
+    "series_index": 29.0
+  },
+  {
+    "id": 7093,
+    "series": "What we do in the Nightless City",
+    "series_index": 6.0
+  },
+  {
+    "id": 7095,
+    "series": "PTA-verse",
+    "series_index": 1.0
+  },
+  {
+    "id": 7100,
+    "series": "flight of a one-winged dove",
+    "series_index": 1.0
+  },
+  {
+    "id": 7114,
+    "series": "BDSM AU",
+    "series_index": 6.0
+  },
+  {
+    "id": 7115,
+    "series": "JTWYA-verse",
+    "series_index": 11.0
+  },
+  {
+    "id": 7117,
+    "series": "Grooming",
+    "series_index": 4.0
+  },
+  {
+    "id": 7125,
+    "series": "CQL WIP Amnesty",
+    "series_index": 1.0
+  },
+  {
+    "id": 7132,
+    "series": "CQL WIP Amnesty",
+    "series_index": 2.0
+  },
+  {
+    "id": 7133,
+    "series": "Fuck off 2021 Ficlets",
+    "series_index": 3.0
+  },
+  {
+    "id": 7134,
+    "series": "Fuck off 2021 Ficlets",
+    "series_index": 6.0
+  },
+  {
+    "id": 7135,
+    "series": "Fuck off 2021 Ficlets",
+    "series_index": 4.0
+  },
+  {
+    "id": 7136,
+    "series": "Fuck off 2021 Ficlets",
+    "series_index": 5.0
+  },
+  {
+    "id": 7140,
+    "series": "the crane and his crow",
+    "series_index": 1.0
+  },
+  {
+    "id": 7151,
+    "series": "CQL WIP Amnesty",
+    "series_index": 3.0
+  },
+  {
+    "id": 7158,
+    "series": "frayed",
+    "series_index": 8.0
+  },
+  {
+    "id": 7164,
+    "series": "if living can be this",
+    "series_index": 10.0
+  },
+  {
+    "id": 7166,
+    "series": "orchidverse",
+    "series_index": 1.0
+  },
+  {
+    "id": 7177,
+    "series": "I want to be bruised by god",
+    "series_index": 2.0
+  },
+  {
+    "id": 7178,
+    "series": "I want to be bruised by god",
+    "series_index": 1.0
+  },
+  {
+    "id": 7179,
+    "series": "if living can be this",
+    "series_index": 11.0
+  },
+  {
+    "id": 7195,
+    "series": "the places Nobody knows",
+    "series_index": 5.0
+  },
+  {
+    "id": 7199,
+    "series": "drabbles",
+    "series_index": 2.0
+  },
+  {
+    "id": 7202,
+    "series": "drabbles",
+    "series_index": 1.0
+  },
+  {
+    "id": 7203,
+    "series": "BDSM AU",
+    "series_index": 2.0
+  },
+  {
+    "id": 7206,
+    "series": "Sweaters and Slippers",
+    "series_index": 2.0
+  },
+  {
+    "id": 7213,
+    "series": "This Type of Love Don't Always Come &amp; Go",
+    "series_index": 2.0
+  },
+  {
+    "id": 7216,
+    "series": "evidence of a love that transcends hunger",
+    "series_index": 1.0
+  },
+  {
+    "id": 7219,
+    "series": "evidence of a love that transcends hunger",
+    "series_index": 2.0
+  },
+  {
+    "id": 7220,
+    "series": "evidence of a love that transcends hunger",
+    "series_index": 3.0
+  },
+  {
+    "id": 7230,
+    "series": "if living can be this",
+    "series_index": 12.0
+  },
+  {
+    "id": 7246,
+    "series": "The Woman from Meishan",
+    "series_index": 1.0
+  },
+  {
+    "id": 7249,
+    "series": "Mama Fox",
+    "series_index": 2.0
+  },
+  {
+    "id": 7252,
+    "series": "murderverse",
+    "series_index": 3.0
+  },
+  {
+    "id": 7257,
+    "series": "garden triptych",
+    "series_index": 2.0
+  },
+  {
+    "id": 7266,
+    "series": "the archer, the prey",
+    "series_index": 3.0
+  },
+  {
+    "id": 7273,
+    "series": "Tianchuang Era Zhou Zishu One-shots",
+    "series_index": 10.0
+  },
+  {
+    "id": 7274,
+    "series": "BDSM AU",
+    "series_index": 8.0
+  },
+  {
+    "id": 7281,
+    "series": "Total Power Exchange",
+    "series_index": 3.0
+  },
+  {
+    "id": 7295,
+    "series": "Gender Swap, Three Styles",
+    "series_index": 2.0
+  },
+  {
+    "id": 7306,
+    "series": "Dual Process Theory",
+    "series_index": 1.0
+  },
+  {
+    "id": 7310,
+    "series": "BDSM AU",
+    "series_index": 8.0
+  },
+  {
+    "id": 7312,
+    "series": "Polyship Week 2022",
+    "series_index": 1.0
+  },
+  {
+    "id": 7313,
+    "series": "Polyship Week",
+    "series_index": 1.0
+  },
+  {
+    "id": 7316,
+    "series": "silver clouds, grey linings",
+    "series_index": 11.0
+  },
+  {
+    "id": 7317,
+    "series": "Polyship Week",
+    "series_index": 2.0
+  },
+  {
+    "id": 7320,
+    "series": "Polyship Week",
+    "series_index": 3.0
+  },
+  {
+    "id": 7323,
+    "series": "Polyship Week",
+    "series_index": 4.0
+  },
+  {
+    "id": 7326,
+    "series": "Polyship Week",
+    "series_index": 5.0
+  },
+  {
+    "id": 7328,
+    "series": "The Greatest Catch (meryao)",
+    "series_index": 3.0
+  },
+  {
+    "id": 7332,
+    "series": "to remember names of plants",
+    "series_index": 1.0
+  },
+  {
+    "id": 7334,
+    "series": "MDZS FaeU",
+    "series_index": 1.0
+  },
+  {
+    "id": 7335,
+    "series": "Polyship Week",
+    "series_index": 6.0
+  },
+  {
+    "id": 7336,
+    "series": "equestria girls",
+    "series_index": 2.0
+  },
+  {
+    "id": 7337,
+    "series": "Give a Little",
+    "series_index": 5.0
+  },
+  {
+    "id": 7338,
+    "series": "MDZS Kink Meme Fills",
+    "series_index": 7.0
+  },
+  {
+    "id": 7343,
+    "series": "White jeans/A winter's tale.",
+    "series_index": 2.0
+  },
+  {
+    "id": 7344,
+    "series": "bagel au",
+    "series_index": 2.0
+  },
+  {
+    "id": 7345,
+    "series": "Love, Liu Qingge, and Other Medical Mysteries",
+    "series_index": 1.0
+  },
+  {
+    "id": 7350,
+    "series": "Gimme a Kiss?",
+    "series_index": 6.0
+  },
+  {
+    "id": 7356,
+    "series": "starstruck canonverse",
+    "series_index": 2.0
+  },
+  {
+    "id": 7360,
+    "series": "Twitter Fics",
+    "series_index": 10.0
+  },
+  {
+    "id": 7361,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 80.0
+  },
+  {
+    "id": 7362,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 186.0
+  },
+  {
+    "id": 7365,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 271.0
+  },
+  {
+    "id": 7366,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 344.0
+  },
+  {
+    "id": 7369,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 155.0
+  },
+  {
+    "id": 7372,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 16.0
+  },
+  {
+    "id": 7374,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 277.0
+  },
+  {
+    "id": 7376,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 332.0
+  },
+  {
+    "id": 7377,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 229.0
+  },
+  {
+    "id": 7380,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 94.0
+  },
+  {
+    "id": 7381,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 251.0
+  },
+  {
+    "id": 7382,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 321.0
+  },
+  {
+    "id": 7383,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 42.0
+  },
+  {
+    "id": 7384,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 62.0
+  },
+  {
+    "id": 7385,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 3.0
+  },
+  {
+    "id": 7386,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 81.0
+  },
+  {
+    "id": 7387,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 159.0
+  },
+  {
+    "id": 7391,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 139.0
+  },
+  {
+    "id": 7392,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 49.0
+  },
+  {
+    "id": 7393,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 26.0
+  },
+  {
+    "id": 7394,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 20.0
+  },
+  {
+    "id": 7395,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 268.0
+  },
+  {
+    "id": 7396,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 55.0
+  },
+  {
+    "id": 7397,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 220.0
+  },
+  {
+    "id": 7399,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 85.0
+  },
+  {
+    "id": 7400,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 10.0
+  },
+  {
+    "id": 7401,
+    "series": "Qiye Before and After",
+    "series_index": 3.0
+  },
+  {
+    "id": 7403,
+    "series": "to aim at poetry with pistols",
+    "series_index": 1.0
+  },
+  {
+    "id": 7404,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 184.0
+  },
+  {
+    "id": 7405,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 84.0
+  },
+  {
+    "id": 7406,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 103.0
+  },
+  {
+    "id": 7407,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 335.0
+  },
+  {
+    "id": 7408,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 215.0
+  },
+  {
+    "id": 7409,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 297.0
+  },
+  {
+    "id": 7410,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 328.0
+  },
+  {
+    "id": 7411,
+    "series": "pick up the pieces",
+    "series_index": 3.0
+  },
+  {
+    "id": 7412,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 9.0
+  },
+  {
+    "id": 7414,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 87.0
+  },
+  {
+    "id": 7415,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 89.0
+  },
+  {
+    "id": 7416,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 205.0
+  },
+  {
+    "id": 7417,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 14.0
+  },
+  {
+    "id": 7418,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 171.0
+  },
+  {
+    "id": 7419,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 183.0
+  },
+  {
+    "id": 7420,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 331.0
+  },
+  {
+    "id": 7421,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 124.0
+  },
+  {
+    "id": 7422,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 345.0
+  },
+  {
+    "id": 7423,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 66.0
+  },
+  {
+    "id": 7424,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 194.0
+  },
+  {
+    "id": 7425,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 79.0
+  },
+  {
+    "id": 7426,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 94.0
+  },
+  {
+    "id": 7429,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 285.0
+  },
+  {
+    "id": 7430,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 154.0
+  },
+  {
+    "id": 7431,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 361.0
+  },
+  {
+    "id": 7432,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 273.0
+  },
+  {
+    "id": 7433,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 222.0
+  },
+  {
+    "id": 7434,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 15.0
+  },
+  {
+    "id": 7435,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 165.0
+  },
+  {
+    "id": 7436,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 284.0
+  },
+  {
+    "id": 7438,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 185.0
+  },
+  {
+    "id": 7439,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 113.0
+  },
+  {
+    "id": 7440,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 234.0
+  },
+  {
+    "id": 7443,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 105.0
+  },
+  {
+    "id": 7444,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 24.0
+  },
+  {
+    "id": 7445,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 282.0
+  },
+  {
+    "id": 7446,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 136.0
+  },
+  {
+    "id": 7448,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 149.0
+  },
+  {
+    "id": 7450,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 75.0
+  },
+  {
+    "id": 7452,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 230.0
+  },
+  {
+    "id": 7454,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 258.0
+  },
+  {
+    "id": 7455,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 260.0
+  },
+  {
+    "id": 7457,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 272.0
+  },
+  {
+    "id": 7461,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 301.0
+  },
+  {
+    "id": 7462,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 312.0
+  },
+  {
+    "id": 7463,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 123.0
+  },
+  {
+    "id": 7464,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 339.0
+  },
+  {
+    "id": 7465,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 211.0
+  },
+  {
+    "id": 7467,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 231.0
+  },
+  {
+    "id": 7469,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 287.0
+  },
+  {
+    "id": 7471,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 182.0
+  },
+  {
+    "id": 7472,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 110.0
+  },
+  {
+    "id": 7474,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 359.0
+  },
+  {
+    "id": 7475,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 199.0
+  },
+  {
+    "id": 7476,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 50.0
+  },
+  {
+    "id": 7478,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 146.0
+  },
+  {
+    "id": 7480,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 127.0
+  },
+  {
+    "id": 7481,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 17.0
+  },
+  {
+    "id": 7482,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 289.0
+  },
+  {
+    "id": 7483,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 97.0
+  },
+  {
+    "id": 7484,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 60.0
+  },
+  {
+    "id": 7485,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 352.0
+  },
+  {
+    "id": 7487,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 141.0
+  },
+  {
+    "id": 7488,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 322.0
+  },
+  {
+    "id": 7490,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 115.0
+  },
+  {
+    "id": 7491,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 235.0
+  },
+  {
+    "id": 7492,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 263.0
+  },
+  {
+    "id": 7493,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 300.0
+  },
+  {
+    "id": 7494,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 265.0
+  },
+  {
+    "id": 7496,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 314.0
+  },
+  {
+    "id": 7497,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 70.0
+  },
+  {
+    "id": 7499,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 133.0
+  },
+  {
+    "id": 7500,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 262.0
+  },
+  {
+    "id": 7501,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 25.0
+  },
+  {
+    "id": 7502,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 362.0
+  },
+  {
+    "id": 7503,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 256.0
+  },
+  {
+    "id": 7504,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 365.0
+  },
+  {
+    "id": 7505,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 221.0
+  },
+  {
+    "id": 7506,
+    "series": "to aim at poetry with pistols",
+    "series_index": 2.0
+  },
+  {
+    "id": 7507,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 109.0
+  },
+  {
+    "id": 7508,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 131.0
+  },
+  {
+    "id": 7509,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 190.0
+  },
+  {
+    "id": 7510,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 247.0
+  },
+  {
+    "id": 7511,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 143.0
+  },
+  {
+    "id": 7513,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 325.0
+  },
+  {
+    "id": 7515,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 223.0
+  },
+  {
+    "id": 7518,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 179.0
+  },
+  {
+    "id": 7519,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 61.0
+  },
+  {
+    "id": 7521,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 323.0
+  },
+  {
+    "id": 7523,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 31.0
+  },
+  {
+    "id": 7524,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 293.0
+  },
+  {
+    "id": 7526,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 281.0
+  },
+  {
+    "id": 7527,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 150.0
+  },
+  {
+    "id": 7529,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 259.0
+  },
+  {
+    "id": 7530,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 244.0
+  },
+  {
+    "id": 7531,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 135.0
+  },
+  {
+    "id": 7533,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 307.0
+  },
+  {
+    "id": 7534,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 201.0
+  },
+  {
+    "id": 7535,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 232.0
+  },
+  {
+    "id": 7536,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 308.0
+  },
+  {
+    "id": 7537,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 74.0
+  },
+  {
+    "id": 7538,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 73.0
+  },
+  {
+    "id": 7540,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 18.0
+  },
+  {
+    "id": 7541,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 130.0
+  },
+  {
+    "id": 7543,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 33.0
+  },
+  {
+    "id": 7544,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 237.0
+  },
+  {
+    "id": 7545,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 119.0
+  },
+  {
+    "id": 7547,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 47.0
+  },
+  {
+    "id": 7548,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 219.0
+  },
+  {
+    "id": 7549,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 40.0
+  },
+  {
+    "id": 7550,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 173.0
+  },
+  {
+    "id": 7551,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 274.0
+  },
+  {
+    "id": 7552,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 2.0
+  },
+  {
+    "id": 7553,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 364.0
+  },
+  {
+    "id": 7555,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 292.0
+  },
+  {
+    "id": 7556,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 142.0
+  },
+  {
+    "id": 7557,
+    "series": "pillows",
+    "series_index": 5.0
+  },
+  {
+    "id": 7559,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 125.0
+  },
+  {
+    "id": 7560,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 357.0
+  },
+  {
+    "id": 7562,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 313.0
+  },
+  {
+    "id": 7563,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 147.0
+  },
+  {
+    "id": 7564,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 35.0
+  },
+  {
+    "id": 7566,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 245.0
+  },
+  {
+    "id": 7567,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 298.0
+  },
+  {
+    "id": 7569,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 148.0
+  },
+  {
+    "id": 7570,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 162.0
+  },
+  {
+    "id": 7571,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 290.0
+  },
+  {
+    "id": 7572,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 238.0
+  },
+  {
+    "id": 7573,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 218.0
+  },
+  {
+    "id": 7577,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 65.0
+  },
+  {
+    "id": 7579,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 167.0
+  },
+  {
+    "id": 7583,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 7.0
+  },
+  {
+    "id": 7584,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 236.0
+  },
+  {
+    "id": 7585,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 227.0
+  },
+  {
+    "id": 7586,
+    "series": "Fuck off 2021 Ficlets",
+    "series_index": 1.0
+  },
+  {
+    "id": 7587,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 216.0
+  },
+  {
+    "id": 7589,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 12.0
+  },
+  {
+    "id": 7590,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 106.0
+  },
+  {
+    "id": 7591,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 189.0
+  },
+  {
+    "id": 7593,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 108.0
+  },
+  {
+    "id": 7595,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 300.0
+  },
+  {
+    "id": 7596,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 270.0
+  },
+  {
+    "id": 7597,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 54.0
+  },
+  {
+    "id": 7598,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 366.0
+  },
+  {
+    "id": 7599,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 303.0
+  },
+  {
+    "id": 7600,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 30.0
+  },
+  {
+    "id": 7603,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 32.0
+  },
+  {
+    "id": 7605,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 363.0
+  },
+  {
+    "id": 7606,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 311.0
+  },
+  {
+    "id": 7607,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 91.0
+  },
+  {
+    "id": 7611,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 28.0
+  },
+  {
+    "id": 7612,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 346.0
+  },
+  {
+    "id": 7613,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 367.0
+  },
+  {
+    "id": 7614,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 6.0
+  },
+  {
+    "id": 7615,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 311.0
+  },
+  {
+    "id": 7617,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 121.0
+  },
+  {
+    "id": 7619,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 4.0
+  },
+  {
+    "id": 7622,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 41.0
+  },
+  {
+    "id": 7623,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 275.0
+  },
+  {
+    "id": 7624,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 243.0
+  },
+  {
+    "id": 7625,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 342.0
+  },
+  {
+    "id": 7626,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 114.0
+  },
+  {
+    "id": 7627,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 224.0
+  },
+  {
+    "id": 7628,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 58.0
+  },
+  {
+    "id": 7629,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 193.0
+  },
+  {
+    "id": 7630,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 350.0
+  },
+  {
+    "id": 7631,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 110.0
+  },
+  {
+    "id": 7632,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 143.0
+  },
+  {
+    "id": 7633,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 158.0
+  },
+  {
+    "id": 7634,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 122.0
+  },
+  {
+    "id": 7635,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 354.0
+  },
+  {
+    "id": 7636,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 13.0
+  },
+  {
+    "id": 7638,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 29.0
+  },
+  {
+    "id": 7639,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 225.0
+  },
+  {
+    "id": 7640,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 203.0
+  },
+  {
+    "id": 7641,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 353.0
+  },
+  {
+    "id": 7642,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 83.0
+  },
+  {
+    "id": 7643,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 355.0
+  },
+  {
+    "id": 7645,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 104.0
+  },
+  {
+    "id": 7648,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 101.0
+  },
+  {
+    "id": 7650,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 8.0
+  },
+  {
+    "id": 7651,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 175.0
+  },
+  {
+    "id": 7652,
+    "series": "Jet Black Crow",
+    "series_index": 2.0
+  },
+  {
+    "id": 7653,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 252.0
+  },
+  {
+    "id": 7654,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 347.0
+  },
+  {
+    "id": 7655,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 255.0
+  },
+  {
+    "id": 7656,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 27.0
+  },
+  {
+    "id": 7658,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 160.0
+  },
+  {
+    "id": 7659,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 46.0
+  },
+  {
+    "id": 7660,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 286.0
+  },
+  {
+    "id": 7662,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 82.0
+  },
+  {
+    "id": 7663,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 181.0
+  },
+  {
+    "id": 7664,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 163.0
+  },
+  {
+    "id": 7666,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 221.0
+  },
+  {
+    "id": 7667,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 264.0
+  },
+  {
+    "id": 7668,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 137.0
+  },
+  {
+    "id": 7669,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 172.0
+  },
+  {
+    "id": 7670,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 5.0
+  },
+  {
+    "id": 7671,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 68.0
+  },
+  {
+    "id": 7674,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 174.0
+  },
+  {
+    "id": 7677,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 23.0
+  },
+  {
+    "id": 7678,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 261.0
+  },
+  {
+    "id": 7679,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 153.0
+  },
+  {
+    "id": 7682,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 64.0
+  },
+  {
+    "id": 7683,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 178.0
+  },
+  {
+    "id": 7685,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 337.0
+  },
+  {
+    "id": 7689,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 289.0
+  },
+  {
+    "id": 7691,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 169.0
+  },
+  {
+    "id": 7692,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 269.0
+  },
+  {
+    "id": 7693,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 78.0
+  },
+  {
+    "id": 7697,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 106.0
+  },
+  {
+    "id": 7699,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 204.0
+  },
+  {
+    "id": 7700,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 348.0
+  },
+  {
+    "id": 7701,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 295.0
+  },
+  {
+    "id": 7703,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 343.0
+  },
+  {
+    "id": 7704,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 299.0
+  },
+  {
+    "id": 7705,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 296.0
+  },
+  {
+    "id": 7708,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 320.0
+  },
+  {
+    "id": 7711,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 249.0
+  },
+  {
+    "id": 7712,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 333.0
+  },
+  {
+    "id": 7715,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 36.0
+  },
+  {
+    "id": 7716,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 166.0
+  },
+  {
+    "id": 7718,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 39.0
+  },
+  {
+    "id": 7719,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 152.0
+  },
+  {
+    "id": 7720,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 1.0
+  },
+  {
+    "id": 7721,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 196.0
+  },
+  {
+    "id": 7723,
+    "series": "The MDZS Bachelor Universe",
+    "series_index": 2.0
+  },
+  {
+    "id": 7724,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 202.0
+  },
+  {
+    "id": 7725,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 156.0
+  },
+  {
+    "id": 7726,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 19.0
+  },
+  {
+    "id": 7727,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 132.0
+  },
+  {
+    "id": 7728,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 241.0
+  },
+  {
+    "id": 7729,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 246.0
+  },
+  {
+    "id": 7730,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 92.0
+  },
+  {
+    "id": 7731,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 329.0
+  },
+  {
+    "id": 7732,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 317.0
+  },
+  {
+    "id": 7733,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 257.0
+  },
+  {
+    "id": 7734,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 326.0
+  },
+  {
+    "id": 7736,
+    "series": "Qiye Before and After",
+    "series_index": 1.0
+  },
+  {
+    "id": 7737,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 242.0
+  },
+  {
+    "id": 7738,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 276.0
+  },
+  {
+    "id": 7739,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 327.0
+  },
+  {
+    "id": 7741,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 356.0
+  },
+  {
+    "id": 7742,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 48.0
+  },
+  {
+    "id": 7744,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 187.0
+  },
+  {
+    "id": 7747,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 164.0
+  },
+  {
+    "id": 7749,
+    "series": "Jet Black Crow",
+    "series_index": 1.0
+  },
+  {
+    "id": 7750,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 138.0
+  },
+  {
+    "id": 7751,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 180.0
+  },
+  {
+    "id": 7753,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 212.0
+  },
+  {
+    "id": 7754,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 311.0
+  },
+  {
+    "id": 7755,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 228.0
+  },
+  {
+    "id": 7756,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 177.0
+  },
+  {
+    "id": 7757,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 70.0
+  },
+  {
+    "id": 7760,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 43.0
+  },
+  {
+    "id": 7761,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 209.0
+  },
+  {
+    "id": 7762,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 297.0
+  },
+  {
+    "id": 7763,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 310.0
+  },
+  {
+    "id": 7764,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 168.0
+  },
+  {
+    "id": 7765,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 125.0
+  },
+  {
+    "id": 7767,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 134.0
+  },
+  {
+    "id": 7768,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 358.0
+  },
+  {
+    "id": 7769,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 198.0
+  },
+  {
+    "id": 7770,
+    "series": "Bruised Words",
+    "series_index": 1.0
+  },
+  {
+    "id": 7772,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 233.0
+  },
+  {
+    "id": 7773,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 90.0
+  },
+  {
+    "id": 7775,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 145.0
+  },
+  {
+    "id": 7776,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 52.0
+  },
+  {
+    "id": 7778,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 214.0
+  },
+  {
+    "id": 7779,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 59.0
+  },
+  {
+    "id": 7780,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 217.0
+  },
+  {
+    "id": 7781,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 279.0
+  },
+  {
+    "id": 7782,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 351.0
+  },
+  {
+    "id": 7783,
+    "series": "Fuck off 2021 Ficlets",
+    "series_index": 2.0
+  },
+  {
+    "id": 7784,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 360.0
+  },
+  {
+    "id": 7785,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 116.0
+  },
+  {
+    "id": 7786,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 102.0
+  },
+  {
+    "id": 7787,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 294.0
+  },
+  {
+    "id": 7788,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 63.0
+  },
+  {
+    "id": 7789,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 206.0
+  },
+  {
+    "id": 7790,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 248.0
+  },
+  {
+    "id": 7791,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 72.0
+  },
+  {
+    "id": 7792,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 77.0
+  },
+  {
+    "id": 7793,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 207.0
+  },
+  {
+    "id": 7794,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 239.0
+  },
+  {
+    "id": 7795,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 312.0
+  },
+  {
+    "id": 7796,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 254.0
+  },
+  {
+    "id": 7798,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 213.0
+  },
+  {
+    "id": 7799,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 280.0
+  },
+  {
+    "id": 7800,
+    "series": "The MDZS Bachelor Universe",
+    "series_index": 3.0
+  },
+  {
+    "id": 7802,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 100.0
+  },
+  {
+    "id": 7804,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 197.0
+  },
+  {
+    "id": 7805,
+    "series": "vessel",
+    "series_index": 2.0
+  },
+  {
+    "id": 7807,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 330.0
+  },
+  {
+    "id": 7809,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 195.0
+  },
+  {
+    "id": 7811,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 86.0
+  },
+  {
+    "id": 7813,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 338.0
+  },
+  {
+    "id": 7816,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 266.0
+  },
+  {
+    "id": 7820,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 188.0
+  },
+  {
+    "id": 7821,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 38.0
+  },
+  {
+    "id": 7823,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 37.0
+  },
+  {
+    "id": 7824,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 240.0
+  },
+  {
+    "id": 7825,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 200.0
+  },
+  {
+    "id": 7826,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 88.0
+  },
+  {
+    "id": 7828,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 334.0
+  },
+  {
+    "id": 7829,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 111.0
+  },
+  {
+    "id": 7830,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 129.0
+  },
+  {
+    "id": 7831,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 74.0
+  },
+  {
+    "id": 7832,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 318.0
+  },
+  {
+    "id": 7834,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 298.0
+  },
+  {
+    "id": 7836,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 309.0
+  },
+  {
+    "id": 7839,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 22.0
+  },
+  {
+    "id": 7840,
+    "series": "The embers/After whom... (Yexie Reincarnation-Verse)",
+    "series_index": 2.0
+  },
+  {
+    "id": 7841,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 117.0
+  },
+  {
+    "id": 7842,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 56.0
+  },
+  {
+    "id": 7843,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 250.0
+  },
+  {
+    "id": 7844,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 34.0
+  },
+  {
+    "id": 7845,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 176.0
+  },
+  {
+    "id": 7847,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 140.0
+  },
+  {
+    "id": 7848,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 226.0
+  },
+  {
+    "id": 7849,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 324.0
+  },
+  {
+    "id": 7850,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 341.0
+  },
+  {
+    "id": 7851,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 294.0
+  },
+  {
+    "id": 7853,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 151.0
+  },
+  {
+    "id": 7854,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 208.0
+  },
+  {
+    "id": 7856,
+    "series": "Bruised Words",
+    "series_index": 2.0
+  },
+  {
+    "id": 7859,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 253.0
+  },
+  {
+    "id": 7860,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 51.0
+  },
+  {
+    "id": 7863,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 170.0
+  },
+  {
+    "id": 7865,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 67.0
+  },
+  {
+    "id": 7866,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 349.0
+  },
+  {
+    "id": 7868,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 97.0
+  },
+  {
+    "id": 7869,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 336.0
+  },
+  {
+    "id": 7870,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 267.0
+  },
+  {
+    "id": 7871,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 44.0
+  },
+  {
+    "id": 7872,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 157.0
+  },
+  {
+    "id": 7873,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 210.0
+  },
+  {
+    "id": 7874,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 53.0
+  },
+  {
+    "id": 7875,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 93.0
+  },
+  {
+    "id": 7876,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 96.0
+  },
+  {
+    "id": 7878,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 120.0
+  },
+  {
+    "id": 7879,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 278.0
+  },
+  {
+    "id": 7882,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 283.0
+  },
+  {
+    "id": 7883,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 191.0
+  },
+  {
+    "id": 7887,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 21.0
+  },
+  {
+    "id": 7888,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 128.0
+  },
+  {
+    "id": 7891,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 385.0
+  },
+  {
+    "id": 7892,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 11.0
+  },
+  {
+    "id": 7895,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 370.0
+  },
+  {
+    "id": 7896,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 390.0
+  },
+  {
+    "id": 7897,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 374.0
+  },
+  {
+    "id": 7898,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 386.0
+  },
+  {
+    "id": 7900,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 161.0
+  },
+  {
+    "id": 7901,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 368.0
+  },
+  {
+    "id": 7902,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 45.0
+  },
+  {
+    "id": 7903,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 373.0
+  },
+  {
+    "id": 7905,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 372.0
+  },
+  {
+    "id": 7906,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 379.0
+  },
+  {
+    "id": 7907,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 376.0
+  },
+  {
+    "id": 7909,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 118.0
+  },
+  {
+    "id": 7910,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 99.0
+  },
+  {
+    "id": 7911,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 369.0
+  },
+  {
+    "id": 7912,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 371.0
+  },
+  {
+    "id": 7913,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 380.0
+  },
+  {
+    "id": 7915,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 381.0
+  },
+  {
+    "id": 7916,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 391.0
+  },
+  {
+    "id": 7917,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 384.0
+  },
+  {
+    "id": 7918,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 382.0
+  },
+  {
+    "id": 7920,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 387.0
+  },
+  {
+    "id": 7921,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 288.0
+  },
+  {
+    "id": 7922,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 378.0
+  },
+  {
+    "id": 7924,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 388.0
+  },
+  {
+    "id": 7925,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 389.0
+  },
+  {
+    "id": 7928,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 383.0
+  },
+  {
+    "id": 7929,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 375.0
+  },
+  {
+    "id": 7930,
+    "series": "Fanfiction.net/Livejournal Archive Project",
+    "series_index": 377.0
+  },
+  {
+    "id": 7931,
+    "series": "MDZS/CQL/The Untamed: character studies",
+    "series_index": 16.0
+  },
+  {
+    "id": 7932,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 10.0
+  },
+  {
+    "id": 7933,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 12.0
+  },
+  {
+    "id": 7934,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 26.0
+  },
+  {
+    "id": 7935,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 6.0
+  },
+  {
+    "id": 7936,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 19.0
+  },
+  {
+    "id": 7937,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 20.0
+  },
+  {
+    "id": 7938,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 8.0
+  },
+  {
+    "id": 7939,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 18.0
+  },
+  {
+    "id": 7940,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 24.0
+  },
+  {
+    "id": 7941,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 14.0
+  },
+  {
+    "id": 7942,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 23.0
+  },
+  {
+    "id": 7943,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 22.0
+  },
+  {
+    "id": 7944,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 7.0
+  },
+  {
+    "id": 7945,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 9.0
+  },
+  {
+    "id": 7946,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 17.0
+  },
+  {
+    "id": 7947,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 27.0
+  },
+  {
+    "id": 7948,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 5.0
+  },
+  {
+    "id": 7949,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 29.0
+  },
+  {
+    "id": 7950,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 1.0
+  },
+  {
+    "id": 7951,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 16.0
+  },
+  {
+    "id": 7952,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 13.0
+  },
+  {
+    "id": 7953,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 3.0
+  },
+  {
+    "id": 7954,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 25.0
+  },
+  {
+    "id": 7955,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 4.0
+  },
+  {
+    "id": 7956,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 28.0
+  },
+  {
+    "id": 7957,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 15.0
+  },
+  {
+    "id": 7958,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 2.0
+  },
+  {
+    "id": 7959,
+    "series": "Into The Unknown (a mixtape AU)",
+    "series_index": 21.0
+  },
+  {
+    "id": 8004,
+    "series": "goddamn scribbles on my skin",
+    "series_index": 1.0
+  },
+  {
+    "id": 8006,
+    "series": "under pressure [college AU]",
+    "series_index": 1.0
+  },
+  {
+    "id": 8023,
+    "series": "Learning to Loathe the Taste of Suffering",
+    "series_index": 1.0
+  },
+  {
+    "id": 8036,
+    "series": "solarpunk au",
+    "series_index": 1.0
+  },
+  {
+    "id": 8048,
+    "series": "Sacrifice",
+    "series_index": 10.0
+  },
+  {
+    "id": 8055,
+    "series": "Sacrifice",
+    "series_index": 1.0
+  },
+  {
+    "id": 8058,
+    "series": "Enmeshed",
+    "series_index": 1.0
+  }
+]

--- a/scripts/filter_series.py
+++ b/scripts/filter_series.py
@@ -1,0 +1,20 @@
+import json
+
+with open("books_in_series.json") as f:
+    books_in_series = json.loads(f.read())
+
+series = {}
+for book in books_in_series:
+    if book["series"] not in series.keys():
+        series[book["series"]] = [book["series_index"]]
+    else:
+        series[book["series"]].append(book["series_index"])
+
+print(series)
+# print(len(series))
+
+for title, indices in series.items():
+    if 1.0 not in indices:
+        print(title)
+        print(indices)
+

--- a/scripts/filter_series.py
+++ b/scripts/filter_series.py
@@ -17,4 +17,3 @@ for title, indices in series.items():
     if 1.0 not in indices:
         print(title)
         print(indices)
-

--- a/src/analyse.py
+++ b/src/analyse.py
@@ -12,8 +12,7 @@ from .ao3_utils import (
 from .calibre_utils import get_author_works_count, get_series_works_count
 from .download import download
 from .exceptions import InvalidConfig
-from .utils import log
-from .utils import Bcolors
+from .utils import Bcolors, log
 
 ANALYSIS_TYPES = ["user_subscriptions", "series_subscriptions"]
 

--- a/src/ao3_utils.py
+++ b/src/ao3_utils.py
@@ -3,6 +3,8 @@ import time
 
 from ao3 import AO3
 
+AO3_SERIES_KEYS = ["series00", "series01", "series02", "series03"]
+
 
 def get_ao3_bookmark_urls(
     cookie, expand_series, max_count, user, oldest_date, sort_by_updated

--- a/src/calibre_utils.py
+++ b/src/calibre_utils.py
@@ -7,14 +7,28 @@ series_pattern = re.compile("(.*) \[(.*)\]")
 
 
 def get_series_options(metadata):
-    series_keys = ["series", "series00", "series01", "series02", "series03"]
-    opts = ""
-    for key in series_keys:
-        if len(metadata[key]) > 0:
-            m = series_pattern.match(metadata[key])
-            opts += '--series="{}" --series-index={} '.format(m.group(1), m.group(2))
+    if len(metadata["series"]) > 0:
+        m = series_pattern.match(metadata["series"])
+        return '--series="{}" --series-index={} '.format(m.group(1), m.group(2))
+    return ""
 
-    return opts
+
+def get_extra_series_data(story_id, metadata):
+    # The command to set custom column data is:
+    # 'calibredb set_custom [options] column id value'
+    # Here we return a list of (column, value) tuples for each additional series
+    # field that contains data, plus its index.
+    existing_series = metadata["series"]
+    series_keys = ["series00", "series01", "series02", "series03"]
+    result = []
+    for key in series_keys:
+        print(key, metadata[key])
+        if len(metadata[key]) > 0 and metadata[key] != existing_series:
+            m = series_pattern.match(metadata[key])
+            result.append((key, m.group(0)))
+            # result.append(("{}-index".format(key), m.group(2)))
+
+    return result
 
 
 def get_tags_options(metadata):

--- a/src/calibre_utils.py
+++ b/src/calibre_utils.py
@@ -3,7 +3,82 @@ import locale
 import re
 from subprocess import PIPE, STDOUT, check_output
 
+from .ao3_utils import AO3_SERIES_KEYS
+from .utils import log
+
+ADD_GROUPED_SEARCH_SCRIPT = """from calibre.library import db
+
+db = db("%s").new_api
+db.set_pref("grouped_search_terms", {"allseries": ["series", "series00", "series01", "series02", "series03"]})
+print(db.pref("grouped_search_terms"))
+"""
 series_pattern = re.compile("(.*) \[(.*)\]")
+
+
+def check_or_create_words_column(path):
+    res = check_output(
+        "calibredb custom_columns {}".format(path),
+        shell=True,
+        stderr=STDOUT,
+        stdin=PIPE,
+    )
+    columns = res.decode("utf-8").split("\n")
+    for c in columns:
+        if c.startswith("words ("):
+            return
+
+    log("Adding custom column 'words' to Calibre library")
+    check_output(
+        "calibredb add_custom_column {} words Words int".format(path),
+        shell=True,
+        stderr=STDOUT,
+        stdin=PIPE,
+    )
+
+
+def check_or_create_extra_series_columns(path):
+    res = check_output(
+        "calibredb custom_columns {}".format(path),
+        shell=True,
+        stderr=STDOUT,
+        stdin=PIPE,
+    )
+    # Get rid of the number after each column name, e.g. "columnname (1)"
+    columns = [c.split(" ")[0] for c in res.decode("utf-8").split("\n")]
+    print(set(columns).intersection(AO3_SERIES_KEYS))
+    print(set(AO3_SERIES_KEYS))
+    if set(columns).intersection(AO3_SERIES_KEYS) == set(AO3_SERIES_KEYS):
+        log("Custom AO3 series columns are in Calibre Library")
+    else:
+        log("Adding custom AO3 series columns to Calibre library")
+        for c in AO3_SERIES_KEYS:
+            print("calibredb add_custom_column {} {} {} series".format(path, c, c))
+            check_output(
+                "calibredb add_custom_column {} {} {} series".format(path, c, c),
+                shell=True,
+                stderr=STDOUT,
+                stdin=PIPE,
+            )
+
+    log("Adding grouped search term 'allseries' to Calibre Library")
+    _add_grouped_search_terms(path)
+
+
+def _add_grouped_search_terms(path):
+    # The path that we usually use is constructed out of several parts,
+    # including '--with-path' option and potentially username and password.
+    # Here we just want the path to the library.
+    just_library_path = path.split('"')[1]
+    # Add a new grouped search term "allseries" so that Calibre can search across all
+    # the series columns.
+    script = ADD_GROUPED_SEARCH_SCRIPT % just_library_path
+    res = check_output(
+        "calibre-debug -c '{}'".format(script),
+        shell=True,
+        stderr=STDOUT,
+        stdin=PIPE,
+    )
+    log(res)
 
 
 def get_series_options(metadata):
@@ -22,11 +97,9 @@ def get_extra_series_data(story_id, metadata):
     series_keys = ["series00", "series01", "series02", "series03"]
     result = []
     for key in series_keys:
-        print(key, metadata[key])
         if len(metadata[key]) > 0 and metadata[key] != existing_series:
             m = series_pattern.match(metadata[key])
             result.append((key, m.group(0)))
-            # result.append(("{}-index".format(key), m.group(2)))
 
     return result
 

--- a/src/download.py
+++ b/src/download.py
@@ -26,6 +26,8 @@ from .ao3_utils import (
     get_ao3_work_subscription_urls,
 )
 from .calibre_utils import (
+    check_or_create_extra_series_columns,
+    check_or_create_words_column,
     get_extra_series_data,
     get_series_options,
     get_tags_options,
@@ -146,27 +148,6 @@ def get_url_without_chapter(url):
     url = url.replace("http://", "https://")
     m = story_url.match(url)
     return m.group(1)
-
-
-def check_or_create_words_column(path):
-    res = check_output(
-        "calibredb custom_columns {}".format(path),
-        shell=True,
-        stderr=STDOUT,
-        stdin=PIPE,
-    )
-    columns = res.decode("utf-8").split("\n")
-    for c in columns:
-        if c.startswith("words ("):
-            return
-
-    log("Adding custom column 'words' to Calibre library")
-    check_output(
-        "calibredb add_custom_column {} words Words int".format(path),
-        shell=True,
-        stderr=STDOUT,
-        stdin=PIPE,
-    )
 
 
 def get_new_story_id(bytestring):
@@ -784,6 +765,7 @@ def download(options):
                 return
         try:
             check_or_create_words_column(path)
+            check_or_create_extra_series_columns(path)
         except CalledProcessError as e:
             log(
                 "Error while making sure 'words' column exists in Calibre library",


### PR DESCRIPTION
- Adapt download script to save data for all the AO3 'series' fields that we get from FFF
- Add script to add those columns to the Calibre library, and get list of series that should be re-imported because not all books had the series saved on them properly (because they belong to one or more other series, and only one series can be added to the existing Calibre 'series' field)